### PR TITLE
smaller output shape handling 

### DIFF
--- a/tiktorch/client.py
+++ b/tiktorch/client.py
@@ -311,6 +311,21 @@ class TikTorchClient(object):
         response = self.meta_recv()
         return response['id'] == f'DISPATCHING.{mode.upper()}'
 
+    def dry_run(self, image_shape, train_flag):
+        logger = logging.getLogger('TikTorchClient.dry_run')
+        logger.info("Waiting for lock...")
+        with self._main_lock:
+            logger.info("Requesting dispatch...")
+            assert self.request_dispatch('DRYRUN')
+            logger.info("Request successful.")
+
+            info = {'id': 'DRYRUN.SPEC',
+                    'shape': image_shape,
+                    'flag': train_flag}
+            logger.info('Sending Dry_Run_Spec')
+            self.meta_send(info)
+
+
     def forward(self, inputs: list):
         logger = logging.getLogger('TikTorchClient.forward')
         logger.info("Waiting for lock...")

--- a/tiktorch/wrapper.py
+++ b/tiktorch/wrapper.py
@@ -222,7 +222,7 @@ class TikTorch(object):
         logger.debug("Returning list of {} array(s).".format(len(outputs)))
         return outputs
 
-    def configure(self, *, window_size=None, num_input_channels=None, num_output_channels=None,
+    def configure(self, *, window_size=None, output_size=None, num_input_channels=None, num_output_channels=None,
                   serialize_to_path=None, devices=None):
         """
         Configure the object.
@@ -231,6 +231,10 @@ class TikTorch(object):
         ----------
         window_size : list
             A length specifying the spatial shape of the input. Must be a list of
+            length 2 for 2D images, or one of length 3 for 3D volumes.
+
+        output_size : list
+            A length specifying the spatial shape of the ouput. Must be a list of
             length 2 for 2D images, or one of length 3 for 3D volumes.
 
         num_input_channels : int
@@ -252,6 +256,7 @@ class TikTorch(object):
 
         """
         self.set('window_size', window_size)
+        self.set('output_size', output_size)
         self.set('num_input_channels', num_input_channels)
         self.set('num_output_channels', num_output_channels)
         self.set('serialize_to_path', serialize_to_path)


### PR DESCRIPTION
there is no case to handle smaller output sizes than the expected input shape, so i added a little hack to place the smaller output image into a zero array of the expected input shape. 