### PR TITLE
Add conda recipe

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -2,12 +2,10 @@ numpy:
   - 1.12
 python:
   - 3.6
-tifffile:
-  - 0.4.post2
 package_name:
   - tiktorch
   - tiktorch-client
 pytorch_version:
   - 1.0
 inferno_version:
-  - 0.3
+  - 0.3.3

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -5,19 +5,9 @@ python:
 tifffile:
   - 0.4.post2
 package_name:
-  - tiktorch-cpu
   - tiktorch
-pytorch_flavor:
-  - pytorch-cpu
-  - pytorch
-inferno_flavor:
-  - inferno-cpu
-  - inferno
+  - tiktorch-client
 pytorch_version:
-  - 0.4.1
+  - 1.0
 inferno_version:
-  - 0.2
-zip_keys:
-  - package_name
-  - pytorch_flavor
-  - inferno_flavor
+  - 0.3

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,0 +1,23 @@
+numpy:
+  - 1.12
+python:
+  - 3.6
+tifffile:
+  - 0.4.post2
+package_name:
+  - tiktorch-cpu
+  - tiktorch
+pytorch_flavor:
+  - pytorch-cpu
+  - pytorch
+inferno_flavor:
+  - inferno-cpu
+  - inferno
+pytorch_version:
+  - 0.4.1
+inferno_version:
+  - 0.2
+zip_keys:
+  - package_name
+  - pytorch_flavor
+  - inferno_flavor

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,11 +1,11 @@
 numpy:
-  - 1.12
+  - 1.14
 python:
-  - 3.6
+  - 3.7
 package_name:
   - tiktorch
   - tiktorch-client
 pytorch_version:
   - 1.0
 inferno_version:
-  - 0.3.3
+  - v0.4

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
    {{tagged_version}}
 
 source:
-  path: ..
+  path: ../
 
 build:
   number: 1
@@ -27,10 +27,7 @@ requirements:
     - numpy {{ numpy }}*
     - pyyaml
     - paramiko
-    - scipy
-    - tensorboardX
-    - tifffile {{ tifffile }}*
-    - tqdm
+    - pyzmq
     - zeromq
 
     {% if not "client" in package_name %}

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,11 +23,16 @@ requirements:
     - pip
     - python {{ python }}
   run:
+    - h5py
     - numpy {{ numpy }}*
     - pyyaml
+    - paramiko
     - scipy
+    - tensorboardX
     - tifffile {{ tifffile }}*
     - tqdm
+    - zeromq
+
     {% if not "client" in package_name %}
     - inferno {{ inferno_version }}*
     - pytorch {{ pytorch_version }}*

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,45 @@
+{% set pytorch_flavor=pytorch_flavor or "pytorch" %}
+{% set inferno_flavor=inferno_flavor or "inferno" %}
+{% set package_name=package_name or "tiktorch" %}
+package:
+  name: {{ package_name }}
+  {% set tagged_version = GIT_DESCRIBE_TAG|replace("v","")|replace("-", ".") %}
+  {% if GIT_DESCRIBE_NUMBER|int != 0 %}
+    {% set tagged_version = tagged_version + '.post' + GIT_DESCRIBE_NUMBER %}
+  {% endif %}
+
+  version:
+   {{tagged_version}}
+
+source:
+  path: ..
+
+build:
+  number: 1
+  script: python -m pip install --no-deps --ignore-installed .
+  string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_h{{PKG_HASH}}_g{{GIT_FULL_HASH[:7]}}
+
+
+requirements:
+  build:
+    - pip
+    - python {{ python }}
+  run:
+    - numpy {{ numpy }}*
+    - pyyaml
+    - scipy
+    - tifffile {{ tifffile }}*
+    - tqdm
+    - {{ inferno_flavor }} {{ inferno_version }}*
+    - {{ pytorch_flavor }} {{ pytorch_version }}*
+
+
+test:
+  imports:
+    - tiktorch
+  # source_files:
+  #   - tests/*.py
+  # requires:
+  #   - pytest
+  # commands:
+  #   - pytest

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,3 @@
-{% set pytorch_flavor=pytorch_flavor or "pytorch" %}
-{% set inferno_flavor=inferno_flavor or "inferno" %}
 {% set package_name=package_name or "tiktorch" %}
 package:
   name: {{ package_name }}
@@ -30,8 +28,10 @@ requirements:
     - scipy
     - tifffile {{ tifffile }}*
     - tqdm
-    - {{ inferno_flavor }} {{ inferno_version }}*
-    - {{ pytorch_flavor }} {{ pytorch_version }}*
+    {% if not "client" in package_name %}
+    - inferno {{ inferno_version }}*
+    - pytorch {{ pytorch_version }}*
+    {% endif %}
 
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python {{ python }}
   run:
     - h5py
+    - python {{ python }}*
     - numpy {{ numpy }}*
     - pyyaml
     - paramiko
@@ -31,8 +32,8 @@ requirements:
     - zeromq
 
     {% if not "client" in package_name %}
-    - inferno {{ inferno_version }}*
     - pytorch {{ pytorch_version }}*
+    - inferno {{ inferno_version }}*
     {% endif %}
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ line_length=120
 known_first_party=tiktorch
 multi_line_output=3
 include_trailing_comma=true
+
+[pylint]
+max-line-length=120

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     packages=find_packages(exclude=["tests"]),  # Required
-    install_requires=["inferno-pytorch", "paramiko", "numpy", "pyyaml", "pyzmq", "h5py", "torch"],
-    extras_require={"test": ["pytest"]},
+    install_requires=["inferno-pytorch", "paramiko", "numpy", "pyyaml", "pyzmq", "torch"],
+    # extras_require={"test": ["pytest"]},
     project_urls={  # Optional
         "Bug Reports": "https://github.com/ilastik/tiktorch/issues",
         "Source": "https://github.com/ilastik/tiktorch/",


### PR DESCRIPTION
Right now the `tiktorch` repository serves two purposes:

1) server to do training/prediction
2) client to send and receive data from/to `ilastik`

This PR adds a recipe that builds two variants of `tiktorch`:

1) `tiktorch-client`: client library without dependencies on `inferno`/`pytorch` for use in ilastik
2) `tiktorch`: recipe for the server stuff, dependent on `pytorch`/`inferno`

both are uploaded to [`ilastik-forge`](https://anaconda.org/ilastik-forge/repo) and can be installed via:

```bash
conda install -c ilastik-forge -c conda-forge tiktorch-client
# and:
conda install -c pytorch -c ilastik-forge -c conda-forge tiktorch
```

Todo:

- [x] check all dependencies

_Update_:

btw @FynnBe @johugger what is the current state of the tests. Does it make sense to run them?