### PR TITLE
conda-recipe: go noarch

### DIFF
--- a/conda-recipe-client/meta.yaml
+++ b/conda-recipe-client/meta.yaml
@@ -11,6 +11,7 @@ source:
   git_url: ../
 
 build:
+  noarch: python
   number: {{ GIT_DESCRIBE_NUMBER }}
   script: python -m pip install --no-deps --ignore-installed .
   string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_h{{PKG_HASH}}_g{{GIT_FULL_HASH[:7]}}
@@ -19,10 +20,10 @@ build:
 requirements:
   build:
     - pip
-    - python {{ python }}
+    - python >=3.7
   run:
-    - python {{ python }}*
-    - numpy {{ numpy }}*
+    - python >=3.7
+    - numpy >=1.14
     - pyyaml
     - paramiko
     - pyzmq

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,7 +1,3 @@
-numpy:
-  - 1.14
-python:
-  - 3.7
 pytorch_version:
   - 1.0
 inferno_version:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
   git_url: ../
 
 build:
+  noarch: python
   number: {{ GIT_DESCRIBE_NUMBER }}
   script: python -m pip install --no-deps --ignore-installed .
   string: np{{CONDA_NPY}}py{{CONDA_PY}}_{{PKG_BUILDNUM}}_h{{PKG_HASH}}_g{{GIT_FULL_HASH[:7]}}
@@ -20,11 +21,11 @@ build:
 requirements:
   build:
     - pip
-    - python {{ python }}
+    - python >=3.7
   run:
     - h5py
-    - python {{ python }}*
-    - numpy {{ numpy }}*
+    - python >=3.7
+    - numpy >=1.14
     - pyyaml
     - paramiko
     - pyzmq


### PR DESCRIPTION
your recipe doesn't seem to involve any os specific build step, hence it should be noarch. -> one build for all osses.

A question concerning pinning of python and numpy: any reason to be so strict (do you expect newer versions to break anything?)