### PR TITLE
Classify as Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     classifiers=[  # Optional
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
     packages=find_packages(exclude=["tests"]),  # Required


### PR DESCRIPTION
Tiktorch is no longer compatible with python3.6, so remove it from the identifiers