### PR TITLE
added missing git dependency

### DIFF
--- a/conda-recipe-cpu/meta.yaml
+++ b/conda-recipe-cpu/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pip
     - python >=3.7
   run:
+    - git
     - h5py
     - python >=3.7
     - numpy >=1.14

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - pip
     - python >=3.7
   run:
+    - git
     - h5py
     - python >=3.7
     - numpy >=1.14


### PR DESCRIPTION
implementation seems to rely on system git, which might not be there.
added conda-supplied git.

git might not be installed - e.g. on windows systems.

Todo:

- [ ] make sure _this_ git is actually used in binary