### PR TITLE
use same method to clone/pull as parent repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/python-bioimage-io"]
 	path = vendor/python-bioimage-io
-	url = git@github.com:bioimage-io/python-bioimage-io.git
+	url = ../../bioimage-io/python-bioimage-io.git
 [submodule "vendor/pytorch-bioimage-io"]
 	path = vendor/pytorch-bioimage-io
-	url = git@github.com:bioimage-io/pytorch-bioimage-io.git
+	url = ../../bioimage-io/pytorch-bioimage-io.git


### PR DESCRIPTION
forcing ssh clone is annoying when working on many machines.
public keys have to be registered with github...

this will use the same method for fetching the submodules as
the parent repo.