### PR TITLE
fix implementation of scale_linear preproc

### DIFF
--- a/tests/test_server/test_prediction_pipeline/test_preprocessing.py
+++ b/tests/test_server/test_prediction_pipeline/test_preprocessing.py
@@ -7,9 +7,18 @@ from tiktorch.server.prediction_pipeline._preprocessing import ADD_BATCH_DIM, ma
 
 
 def test_scale_linear():
-    spec = Preprocessing(name="scale_linear", kwargs={"offset": 42, "gain": 2})
-    data = xr.DataArray(np.arange(4).reshape(2, 2), dims=("x", "y"))
-    expected = xr.DataArray(np.array([[42, 44], [46, 48]]), dims=("x", "y"))
+    spec = Preprocessing(name="scale_linear", kwargs={"offset": [1, 2, 42], "gain": [1, 2, 3], "axes": "yx"})
+    data = xr.DataArray(np.arange(6).reshape(1, 2, 3), dims=("x", "y", "c"))
+    expected = xr.DataArray(np.array([[[1, 4, 48], [4, 10, 57]]]), dims=("x", "y", "c"))
+    preprocessing = make_preprocessing([spec])
+    result = preprocessing(data)
+    xr.testing.assert_allclose(expected, result)
+
+
+def test_scale_linear_no_channel():
+    spec = Preprocessing(name="scale_linear", kwargs={"offset": 1, "gain": 2, "axes": "yx"})
+    data = xr.DataArray(np.arange(6).reshape(2, 3), dims=("x", "y"))
+    expected = xr.DataArray(np.array([[1, 3, 5], [7, 9, 11]]), dims=("x", "y"))
     preprocessing = make_preprocessing([spec])
     result = preprocessing(data)
     xr.testing.assert_allclose(expected, result)

--- a/tiktorch/server/prediction_pipeline/_preprocessing.py
+++ b/tiktorch/server/prediction_pipeline/_preprocessing.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import numpy as np
 import xarray as xr
 from bioimageio.spec.nodes import Preprocessing
 
@@ -12,8 +13,13 @@ def make_ensure_dtype_preprocessing(dtype):
     return Preprocessing(name="__tiktorch_ensure_dtype", kwargs={"dtype": dtype})
 
 
-def scale_linear(tensor: xr.DataArray, *, gain, offset) -> xr.DataArray:
-    return gain * tensor + offset
+def scale_linear(tensor: xr.DataArray, *, gain, offset, axes) -> xr.DataArray:
+    """scale the tensor with a fixed multiplicative and additive factor"""
+    scale_axes = tuple(ax for ax in tensor.dims if (ax not in axes and ax != "b"))
+    if scale_axes:
+        gain = xr.DataArray(np.atleast_1d(gain), dims=scale_axes)
+        offset = xr.DataArray(np.atleast_1d(offset), dims=scale_axes)
+    return tensor * gain + offset
 
 
 def zero_mean_unit_variance(tensor: xr.DataArray, axes=None, eps=1.0e-6, mode="per_sample") -> xr.DataArray:


### PR DESCRIPTION
[preprocessing spec](https://github.com/bioimage-io/spec-bioimage-io/blob/master/supported_formats_and_operations.md#preprocessing) requires `axes` argument for `scale_linear`. As I read the spec, this argument is _not_ optional. Added tests