### PR TITLE
Improve startup log

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,14 @@ To install tiktorch and start server run:
 conda create -n tiktorch-server-env -c ilastik-forge -c conda-forge -c pytorch tiktorch
 
 conda activate tiktorch-server-env
-
+```
+To run server locally use
+```
 tiktorch-server
+```
+To be able to connect to remote machine use (this will bind to all available addresses)
+```
+tiktorch-server --addr 0.0.0.0
 ```
 
 ## Development environment

--- a/tests/test_server/test_device_pool.py
+++ b/tests/test_server/test_device_pool.py
@@ -1,0 +1,17 @@
+import pytest
+import torch.cuda
+import torch.version
+
+from tiktorch.server.device_pool import TorchDevicePool
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda is not available")
+def test_device_pool_with_cuda():
+    device_pool = TorchDevicePool()
+    assert device_pool.cuda_version == torch.version.cuda
+
+
+@pytest.mark.skipif(torch.cuda.is_available(), reason="cuda is available")
+def test_device_pool_without_cuda():
+    device_pool = TorchDevicePool()
+    assert device_pool.cuda_version is None

--- a/tiktorch/server/device_pool.py
+++ b/tiktorch/server/device_pool.py
@@ -5,7 +5,7 @@ import enum
 import threading
 import uuid
 from collections import defaultdict
-from typing import List
+from typing import List, Optional
 
 import torch
 
@@ -60,6 +60,14 @@ class ILease(abc.ABC):
 
 
 class IDevicePool(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def cuda_version(self) -> Optional[str]:
+        """
+        Returns CUDA version if available
+        """
+        ...
+
     @abc.abstractmethod
     def list_devices(self) -> List[IDevice]:
         """
@@ -111,6 +119,13 @@ class TorchDevicePool(IDevicePool):
         self.__lease_id_by_device_id = {}
         self.__device_ids_by_lease_id = defaultdict(list)
         self.__lock = threading.Lock()
+
+    @property
+    def cuda_version(self) -> Optional[str]:
+        if torch.cuda.is_available():
+            return torch.version.cuda  # type: ignore
+        else:
+            return None
 
     def list_devices(self) -> List[IDevice]:
         with self.__lock:


### PR DESCRIPTION
and update doc for #181
The `0.0.0.0` is not the default value because it will result in open ports on the user machine which can be troublesome from the security perspective
Example of startup log:
```
1521451

CUDA version: 10.1
CUDA_PATH /opt/cuda
CUDA_VISIBLE_DEVICES 0

Available devices:
  * cpu
  * cuda:0

Starting server on 127.0.0.1:5567
```