### PR TITLE
support for all input/output shape types

### DIFF
--- a/proto/inference.proto
+++ b/proto/inference.proto
@@ -55,13 +55,28 @@ message Scale {
    repeated NamedFloat scales = 1;
 }
 
+
+/* InputShape will always be expected to have `shape` set.
+ * For `ShapeType` PARAMETRIZED, also a `stepShape` has to be given.
+ * ref: https://github.com/bioimage-io/spec-bioimage-io/blob/gh-pages/model_spec_latest.md */
+message InputShape {
+  enum ShapeType {
+    EXPLICIT = 0;
+    PARAMETRIZED = 1;
+  }
+
+  ShapeType shapeType = 1;
+  Shape shape = 2;
+  Shape stepShape = 4;
+}
+
 message ModelSession {
   string id = 1;
   string name = 2;
   repeated string inputAxes = 3;
   repeated string outputAxes = 4;
   bool hasTraining = 5;
-  repeated Shape validShapes = 6;
+  repeated InputShape inputShapes = 6;
   repeated Shape halos = 7;
   repeated Scale scales = 8;
   repeated Shape offsets = 9;

--- a/proto/inference.proto
+++ b/proto/inference.proto
@@ -66,8 +66,22 @@ message InputShape {
   }
 
   ShapeType shapeType = 1;
+  // shape is min, when PARAMETRIZED
   Shape shape = 2;
   Shape stepShape = 4;
+}
+
+message OutputShape {
+  enum ShapeType {
+    EXPLICIT = 0;
+    IMPLICIT = 1;
+  }
+  ShapeType shapeType = 1;
+  Shape shape = 2;
+  Shape halo = 3;
+  string referenceTensor = 4;
+  Scale scale = 5;
+  Shape offset = 6;
 }
 
 message ModelSession {
@@ -77,9 +91,7 @@ message ModelSession {
   repeated string outputAxes = 4;
   bool hasTraining = 5;
   repeated InputShape inputShapes = 6;
-  repeated Shape halos = 7;
-  repeated Scale scales = 8;
-  repeated Shape offsets = 9;
+  repeated OutputShape outputShapes = 7;
 }
 
 message LogEntry {

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -3,8 +3,16 @@ import pytest
 import xarray as xr
 from numpy.testing import assert_array_equal
 
-from tiktorch.converters import numpy_to_pb_tensor, pb_tensor_to_numpy, pb_tensor_to_xarray, xarray_to_pb_tensor
+from tiktorch.converters import (
+    numpy_to_pb_tensor,
+    pb_tensor_to_numpy,
+    pb_tensor_to_xarray,
+    xarray_to_pb_tensor,
+    output_shape_to_pb_output_shape,
+    input_shape_to_pb_input_shape,
+)
 from tiktorch.proto import inference_pb2
+from tiktorch.server.session.process import NamedImplicitOutputShape, NamedParametrizedShape, NamedExplicitOutputShape
 
 
 def _numpy_to_pb_tensor(arr):
@@ -173,3 +181,88 @@ class TestPBTensorToXarray:
         tensor = self.to_pb_tensor(arr)
         result_arr = pb_tensor_to_xarray(tensor)
         assert_array_equal(arr, result_arr)
+
+
+class TestShapeConversions:
+    def to_named_explicit_shape(self, shape, axes, halo):
+        return NamedExplicitOutputShape(
+            halo=[(name, dim) for name, dim in zip(axes, halo)], shape=[(name, dim) for name, dim in zip(axes, shape)]
+        )
+
+    def to_named_implicit_shape(self, axes, halo, offset, scales, reference_tensor):
+        return NamedImplicitOutputShape(
+            halo=[(name, dim) for name, dim in zip(axes, halo)],
+            offset=[(name, dim) for name, dim in zip(axes, offset)],
+            scale=[(name, scale) for name, scale in zip(axes, scales)],
+            reference_tensor=reference_tensor,
+        )
+
+    def to_named_paramtrized_shape(self, min_shape, axes, step):
+        return NamedParametrizedShape(
+            min_shape=[(name, dim) for name, dim in zip(axes, min_shape)],
+            step_shape=[(name, dim) for name, dim in zip(axes, step)],
+        )
+
+    @pytest.mark.parametrize(
+        "shape,axes,halo",
+        [((42,), "x", (0,)), ((42, 128, 5), "abc", (1, 1, 1)), ((5, 4, 3, 2, 1, 42), "btzyxc", (1, 2, 3, 4, 5, 24))],
+    )
+    def test_explicit_output_shape(self, shape, axes, halo):
+        named_shape = self.to_named_explicit_shape(shape, axes, halo)
+        pb_shape = output_shape_to_pb_output_shape(named_shape)
+
+        assert pb_shape.shapeType == 0
+        assert pb_shape.referenceTensor == ""
+        assert len(pb_shape.scale.scales) == 0
+        assert len(pb_shape.offset.dims) == 0
+
+        assert [(d.name, d.size) for d in pb_shape.halo.dims] == [(name, size) for name, size in zip(axes, halo)]
+        assert [(d.name, d.size) for d in pb_shape.shape.dims] == [(name, size) for name, size in zip(axes, shape)]
+
+    @pytest.mark.parametrize(
+        "axes,halo,offset,scales,reference_tensor",
+        [("x", (0,), (10,), (1.0,), "forty-two"), ("abc", (1, 1, 1), (1, 2, 3), (1.0, 2.0, 3.0), "helloworld")],
+    )
+    def test_implicit_output_shape(self, axes, halo, offset, scales, reference_tensor):
+        named_shape = self.to_named_implicit_shape(axes, halo, offset, scales, reference_tensor)
+        pb_shape = output_shape_to_pb_output_shape(named_shape)
+
+        assert pb_shape.shapeType == 1
+        assert pb_shape.referenceTensor == reference_tensor
+        assert [(d.name, d.size) for d in pb_shape.scale.scales] == [(name, size) for name, size in zip(axes, scales)]
+        assert [(d.name, d.size) for d in pb_shape.offset.dims] == [(name, size) for name, size in zip(axes, offset)]
+
+        assert [(d.name, d.size) for d in pb_shape.halo.dims] == [(name, size) for name, size in zip(axes, halo)]
+        assert len(pb_shape.shape.dims) == 0
+
+    def test_output_shape_raises(self):
+        shape = [("a", 1)]
+        with pytest.raises(TypeError):
+            _ = output_shape_to_pb_output_shape(shape)
+
+    @pytest.mark.parametrize(
+        "shape,axes",
+        [((42,), "x"), ((42, 128, 5), "abc"), ((5, 4, 3, 2, 1, 42), "btzyxc")],
+    )
+    def test_explicit_input_shape(self, shape, axes):
+        named_shape = [(name, dim) for name, dim in zip(axes, shape)]
+        pb_shape = input_shape_to_pb_input_shape(named_shape)
+
+        assert pb_shape.shapeType == 0
+        assert [(d.name, d.size) for d in pb_shape.shape.dims] == [(name, size) for name, size in zip(axes, shape)]
+
+    @pytest.mark.parametrize(
+        "min_shape,axes,step",
+        [
+            ((42,), "x", (5,)),
+            ((42, 128, 5), "abc", (1, 2, 3)),
+            ((5, 4, 3, 2, 1, 42), "btzyxc", (15, 24, 33, 42, 51, 642)),
+        ],
+    )
+    def test_parametrized_input_shape(self, min_shape, axes, step):
+        named_shape = self.to_named_paramtrized_shape(min_shape, axes, step)
+        pb_shape = input_shape_to_pb_input_shape(named_shape)
+
+        assert pb_shape.shapeType == 1
+        assert [(d.name, d.size) for d in pb_shape.shape.dims] == [(name, size) for name, size in zip(axes, min_shape)]
+        assert [(d.name, d.size) for d in pb_shape.stepShape.dims] == [(name, size) for name, size in zip(axes, step)]

--- a/tests/test_server/test_grpc/test_inference_servicer.py
+++ b/tests/test_server/test_grpc/test_inference_servicer.py
@@ -47,8 +47,8 @@ class TestModelManagement:
     def test_model_session_creation(self, grpc_stub, bioimageio_model_bytes):
         model = grpc_stub.CreateModelSession(valid_model_request(bioimageio_model_bytes))
         assert model.id
-        assert hasattr(model, "scales")
-        assert hasattr(model, "offsets")
+        assert hasattr(model, "outputShapes")
+        assert hasattr(model, "inputShapes")
         grpc_stub.CloseModelSession(model)
 
     def test_model_session_creation_using_upload_id(self, grpc_stub, data_store, bioimageio_dummy_model_bytes):

--- a/tiktorch/converters.py
+++ b/tiktorch/converters.py
@@ -4,7 +4,12 @@ import numpy as np
 import xarray as xr
 
 from tiktorch.proto import inference_pb2
-from tiktorch.server.session.process import NamedParametrizedShape, NamedShape
+from tiktorch.server.session.process import (
+    NamedExplicitOutputShape,
+    NamedImplicitOutputShape,
+    NamedParametrizedShape,
+    NamedShape,
+)
 
 
 def numpy_to_pb_tensor(array: np.ndarray, axistags=None) -> inference_pb2.Tensor:
@@ -43,6 +48,28 @@ def input_shape_to_pb_input_shape(input_shape: Union[NamedShape, NamedParametriz
             shapeType=0,
             shape=name_int_tuples_to_pb_shape(input_shape),
         )
+
+
+def output_shape_to_pb_output_shape(
+    output_shape: Union[NamedExplicitOutputShape, NamedImplicitOutputShape]
+) -> inference_pb2.InputShape:
+
+    if isinstance(output_shape, NamedImplicitOutputShape):
+        return inference_pb2.OutputShape(
+            shapeType=1,
+            halo=name_int_tuples_to_pb_shape(output_shape.halo),
+            referenceTensor=output_shape.reference_tensor,
+            scale=name_float_tuples_to_pb_scale(output_shape.scale),
+            offset=name_int_tuples_to_pb_shape(output_shape.offset),
+        )
+    elif isinstance(output_shape, NamedExplicitOutputShape):
+        return inference_pb2.InputShape(
+            shapeType=0,
+            shape=name_int_tuples_to_pb_shape(output_shape.shape),
+            halo=name_int_tuples_to_pb_shape(output_shape.halo),
+        )
+    else:
+        raise TypeError(f"Conversion not supported for type {type(output_shape)}")
 
 
 def pb_tensor_to_xarray(tensor: inference_pb2.Tensor) -> inference_pb2.Tensor:

--- a/tiktorch/converters.py
+++ b/tiktorch/converters.py
@@ -1,7 +1,10 @@
+from typing import Union
+
 import numpy as np
 import xarray as xr
 
 from tiktorch.proto import inference_pb2
+from tiktorch.server.session.process import NamedParametrizedShape, NamedShape
 
 
 def numpy_to_pb_tensor(array: np.ndarray, axistags=None) -> inference_pb2.Tensor:
@@ -25,6 +28,21 @@ def name_float_tuples_to_pb_scale(name_float_tuples) -> inference_pb2.Shape:
     return inference_pb2.Scale(
         scales=[inference_pb2.NamedFloat(size=dim, name=name) for name, dim in name_float_tuples]
     )
+
+
+def input_shape_to_pb_input_shape(input_shape: Union[NamedShape, NamedParametrizedShape]) -> inference_pb2.InputShape:
+
+    if isinstance(input_shape, NamedParametrizedShape):
+        return inference_pb2.InputShape(
+            shapeType=1,
+            shape=name_int_tuples_to_pb_shape(input_shape.min_shape),
+            stepShape=name_int_tuples_to_pb_shape(input_shape.step_shape),
+        )
+    else:
+        return inference_pb2.InputShape(
+            shapeType=0,
+            shape=name_int_tuples_to_pb_shape(input_shape),
+        )
 
 
 def pb_tensor_to_xarray(tensor: inference_pb2.Tensor) -> inference_pb2.Tensor:

--- a/tiktorch/converters.py
+++ b/tiktorch/converters.py
@@ -63,7 +63,7 @@ def output_shape_to_pb_output_shape(
             offset=name_int_tuples_to_pb_shape(output_shape.offset),
         )
     elif isinstance(output_shape, NamedExplicitOutputShape):
-        return inference_pb2.InputShape(
+        return inference_pb2.OutputShape(
             shapeType=0,
             shape=name_int_tuples_to_pb_shape(output_shape.shape),
             halo=name_int_tuples_to_pb_shape(output_shape.halo),

--- a/tiktorch/proto/inference_pb2.py
+++ b/tiktorch/proto/inference_pb2.py
@@ -6,7 +6,6 @@ from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
-
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -20,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0finference.proto\"Y\n\x06\x44\x65vice\x12\n\n\x02id\x18\x01 \x01(\t\x12\x1e\n\x06status\x18\x02 \x01(\x0e\x32\x0e.Device.Status\"#\n\x06Status\x12\r\n\tAVAILABLE\x10\x00\x12\n\n\x06IN_USE\x10\x01\"W\n\x1f\x43reateDatasetDescriptionRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x0c\n\x04mean\x18\x03 \x01(\x01\x12\x0e\n\x06stddev\x18\x04 \x01(\x01\" \n\x12\x44\x61tasetDescription\x12\n\n\x02id\x18\x01 \x01(\t\"\'\n\x04\x42lob\x12\x0e\n\x06\x66ormat\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\"i\n\x19\x43reateModelSessionRequest\x12\x13\n\tmodel_uri\x18\x01 \x01(\tH\x00\x12\x1b\n\nmodel_blob\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x12\x11\n\tdeviceIds\x18\x05 \x03(\tB\x07\n\x05model\" \n\x05Shape\x12\x17\n\x04\x64ims\x18\x01 \x03(\x0b\x32\t.NamedInt\"$\n\x05Scale\x12\x1b\n\x06scales\x18\x01 \x03(\x0b\x32\x0b.NamedFloat\"\xc9\x01\n\x0cModelSession\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tinputAxes\x18\x03 \x03(\t\x12\x12\n\noutputAxes\x18\x04 \x03(\t\x12\x13\n\x0bhasTraining\x18\x05 \x01(\x08\x12\x1b\n\x0bvalidShapes\x18\x06 \x03(\x0b\x32\x06.Shape\x12\x15\n\x05halos\x18\x07 \x03(\x0b\x32\x06.Shape\x12\x16\n\x06scales\x18\x08 \x03(\x0b\x32\x06.Scale\x12\x17\n\x07offsets\x18\t \x03(\x0b\x32\x06.Shape\"\x9e\x01\n\x08LogEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x1e\n\x05level\x18\x02 \x01(\x0e\x32\x0f.LogEntry.Level\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\t\"N\n\x05Level\x12\n\n\x06NOTSET\x10\x00\x12\t\n\x05\x44\x45\x42UG\x10\x01\x12\x08\n\x04INFO\x10\x02\x12\x0b\n\x07WARNING\x10\x03\x12\t\n\x05\x45RROR\x10\x04\x12\x0c\n\x08\x43RITICAL\x10\x05\"#\n\x07\x44\x65vices\x12\x18\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x07.Device\"&\n\x08NamedInt\x12\x0c\n\x04size\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\"(\n\nNamedFloat\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04name\x18\x02 \x01(\t\"A\n\x06Tensor\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05\x64type\x18\x02 \x01(\t\x12\x18\n\x05shape\x18\x03 \x03(\x0b\x32\t.NamedInt\"U\n\x0ePredictRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x11\n\tdatasetId\x18\x02 \x01(\t\x12\x18\n\x07tensors\x18\x03 \x03(\x0b\x32\x07.Tensor\"+\n\x0fPredictResponse\x12\x18\n\x07tensors\x18\x01 \x03(\x0b\x32\x07.Tensor\"\x07\n\x05\x45mpty\"\x1e\n\tModelInfo\x12\x11\n\tdeviceIds\x18\x01 \x03(\t\"^\n CreateModelSessionChunkedRequest\x12\x1a\n\x04info\x18\x01 \x01(\x0b\x32\n.ModelInfoH\x00\x12\x16\n\x05\x63hunk\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x42\x06\n\x04\x64\x61ta2\xc6\x02\n\tInference\x12\x41\n\x12\x43reateModelSession\x12\x1a.CreateModelSessionRequest\x1a\r.ModelSession\"\x00\x12,\n\x11\x43loseModelSession\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12S\n\x18\x43reateDatasetDescription\x12 .CreateDatasetDescriptionRequest\x1a\x13.DatasetDescription\"\x00\x12 \n\x07GetLogs\x12\x06.Empty\x1a\t.LogEntry\"\x00\x30\x01\x12!\n\x0bListDevices\x12\x06.Empty\x1a\x08.Devices\"\x00\x12.\n\x07Predict\x12\x0f.PredictRequest\x1a\x10.PredictResponse\"\x00\x32G\n\rFlightControl\x12\x18\n\x04Ping\x12\x06.Empty\x1a\x06.Empty\"\x00\x12\x1c\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\x0finference.proto\"Y\n\x06\x44\x65vice\x12\n\n\x02id\x18\x01 \x01(\t\x12\x1e\n\x06status\x18\x02 \x01(\x0e\x32\x0e.Device.Status\"#\n\x06Status\x12\r\n\tAVAILABLE\x10\x00\x12\n\n\x06IN_USE\x10\x01\"W\n\x1f\x43reateDatasetDescriptionRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x0c\n\x04mean\x18\x03 \x01(\x01\x12\x0e\n\x06stddev\x18\x04 \x01(\x01\" \n\x12\x44\x61tasetDescription\x12\n\n\x02id\x18\x01 \x01(\t\"\'\n\x04\x42lob\x12\x0e\n\x06\x66ormat\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\"i\n\x19\x43reateModelSessionRequest\x12\x13\n\tmodel_uri\x18\x01 \x01(\tH\x00\x12\x1b\n\nmodel_blob\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x12\x11\n\tdeviceIds\x18\x05 \x03(\tB\x07\n\x05model\" \n\x05Shape\x12\x17\n\x04\x64ims\x18\x01 \x03(\x0b\x32\t.NamedInt\"$\n\x05Scale\x12\x1b\n\x06scales\x18\x01 \x03(\x0b\x32\x0b.NamedFloat\"\x95\x01\n\nInputShape\x12(\n\tshapeType\x18\x01 \x01(\x0e\x32\x15.InputShape.ShapeType\x12\x15\n\x05shape\x18\x02 \x01(\x0b\x32\x06.Shape\x12\x19\n\tstepShape\x18\x04 \x01(\x0b\x32\x06.Shape\"+\n\tShapeType\x12\x0c\n\x08\x45XPLICIT\x10\x00\x12\x10\n\x0cPARAMETRIZED\x10\x01\"\xce\x01\n\x0cModelSession\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tinputAxes\x18\x03 \x03(\t\x12\x12\n\noutputAxes\x18\x04 \x03(\t\x12\x13\n\x0bhasTraining\x18\x05 \x01(\x08\x12 \n\x0binputShapes\x18\x06 \x03(\x0b\x32\x0b.InputShape\x12\x15\n\x05halos\x18\x07 \x03(\x0b\x32\x06.Shape\x12\x16\n\x06scales\x18\x08 \x03(\x0b\x32\x06.Scale\x12\x17\n\x07offsets\x18\t \x03(\x0b\x32\x06.Shape\"\x9e\x01\n\x08LogEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x1e\n\x05level\x18\x02 \x01(\x0e\x32\x0f.LogEntry.Level\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\t\"N\n\x05Level\x12\n\n\x06NOTSET\x10\x00\x12\t\n\x05\x44\x45\x42UG\x10\x01\x12\x08\n\x04INFO\x10\x02\x12\x0b\n\x07WARNING\x10\x03\x12\t\n\x05\x45RROR\x10\x04\x12\x0c\n\x08\x43RITICAL\x10\x05\"#\n\x07\x44\x65vices\x12\x18\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x07.Device\"&\n\x08NamedInt\x12\x0c\n\x04size\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\"(\n\nNamedFloat\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04name\x18\x02 \x01(\t\"A\n\x06Tensor\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05\x64type\x18\x02 \x01(\t\x12\x18\n\x05shape\x18\x03 \x03(\x0b\x32\t.NamedInt\"U\n\x0ePredictRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x11\n\tdatasetId\x18\x02 \x01(\t\x12\x18\n\x07tensors\x18\x03 \x03(\x0b\x32\x07.Tensor\"+\n\x0fPredictResponse\x12\x18\n\x07tensors\x18\x01 \x03(\x0b\x32\x07.Tensor\"\x07\n\x05\x45mpty\"\x1e\n\tModelInfo\x12\x11\n\tdeviceIds\x18\x01 \x03(\t\"^\n CreateModelSessionChunkedRequest\x12\x1a\n\x04info\x18\x01 \x01(\x0b\x32\n.ModelInfoH\x00\x12\x16\n\x05\x63hunk\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x42\x06\n\x04\x64\x61ta2\xc6\x02\n\tInference\x12\x41\n\x12\x43reateModelSession\x12\x1a.CreateModelSessionRequest\x1a\r.ModelSession\"\x00\x12,\n\x11\x43loseModelSession\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12S\n\x18\x43reateDatasetDescription\x12 .CreateDatasetDescriptionRequest\x1a\x13.DatasetDescription\"\x00\x12 \n\x07GetLogs\x12\x06.Empty\x1a\t.LogEntry\"\x00\x30\x01\x12!\n\x0bListDevices\x12\x06.Empty\x1a\x08.Devices\"\x00\x12.\n\x07Predict\x12\x0f.PredictRequest\x1a\x10.PredictResponse\"\x00\x32G\n\rFlightControl\x12\x18\n\x04Ping\x12\x06.Empty\x1a\x06.Empty\"\x00\x12\x1c\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\"\x00\x62\x06proto3'
 )
 
 
@@ -49,6 +48,31 @@ _DEVICE_STATUS = _descriptor.EnumDescriptor(
   serialized_end=108,
 )
 _sym_db.RegisterEnumDescriptor(_DEVICE_STATUS)
+
+_INPUTSHAPE_SHAPETYPE = _descriptor.EnumDescriptor(
+  name='ShapeType',
+  full_name='InputShape.ShapeType',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='EXPLICIT', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='PARAMETRIZED', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=560,
+  serialized_end=603,
+)
+_sym_db.RegisterEnumDescriptor(_INPUTSHAPE_SHAPETYPE)
 
 _LOGENTRY_LEVEL = _descriptor.EnumDescriptor(
   name='Level',
@@ -90,8 +114,8 @@ _LOGENTRY_LEVEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=738,
-  serialized_end=816,
+  serialized_start=895,
+  serialized_end=973,
 )
 _sym_db.RegisterEnumDescriptor(_LOGENTRY_LEVEL)
 
@@ -368,6 +392,53 @@ _SCALE = _descriptor.Descriptor(
 )
 
 
+_INPUTSHAPE = _descriptor.Descriptor(
+  name='InputShape',
+  full_name='InputShape',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='shapeType', full_name='InputShape.shapeType', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shape', full_name='InputShape.shape', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='stepShape', full_name='InputShape.stepShape', index=2,
+      number=4, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _INPUTSHAPE_SHAPETYPE,
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=454,
+  serialized_end=603,
+)
+
+
 _MODELSESSION = _descriptor.Descriptor(
   name='ModelSession',
   full_name='ModelSession',
@@ -412,7 +483,7 @@ _MODELSESSION = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='validShapes', full_name='ModelSession.validShapes', index=5,
+      name='inputShapes', full_name='ModelSession.inputShapes', index=5,
       number=6, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -451,8 +522,8 @@ _MODELSESSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=454,
-  serialized_end=655,
+  serialized_start=606,
+  serialized_end=812,
 )
 
 
@@ -498,8 +569,8 @@ _LOGENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=658,
-  serialized_end=816,
+  serialized_start=815,
+  serialized_end=973,
 )
 
 
@@ -530,8 +601,8 @@ _DEVICES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=818,
-  serialized_end=853,
+  serialized_start=975,
+  serialized_end=1010,
 )
 
 
@@ -569,8 +640,8 @@ _NAMEDINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=855,
-  serialized_end=893,
+  serialized_start=1012,
+  serialized_end=1050,
 )
 
 
@@ -608,8 +679,8 @@ _NAMEDFLOAT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=895,
-  serialized_end=935,
+  serialized_start=1052,
+  serialized_end=1092,
 )
 
 
@@ -654,8 +725,8 @@ _TENSOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=937,
-  serialized_end=1002,
+  serialized_start=1094,
+  serialized_end=1159,
 )
 
 
@@ -700,8 +771,8 @@ _PREDICTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1004,
-  serialized_end=1089,
+  serialized_start=1161,
+  serialized_end=1246,
 )
 
 
@@ -732,8 +803,8 @@ _PREDICTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1091,
-  serialized_end=1134,
+  serialized_start=1248,
+  serialized_end=1291,
 )
 
 
@@ -757,8 +828,8 @@ _EMPTY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1136,
-  serialized_end=1143,
+  serialized_start=1293,
+  serialized_end=1300,
 )
 
 
@@ -789,8 +860,8 @@ _MODELINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1145,
-  serialized_end=1175,
+  serialized_start=1302,
+  serialized_end=1332,
 )
 
 
@@ -833,8 +904,8 @@ _CREATEMODELSESSIONCHUNKEDREQUEST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1177,
-  serialized_end=1271,
+  serialized_start=1334,
+  serialized_end=1428,
 )
 
 _DEVICE.fields_by_name['status'].enum_type = _DEVICE_STATUS
@@ -848,7 +919,11 @@ _CREATEMODELSESSIONREQUEST.oneofs_by_name['model'].fields.append(
 _CREATEMODELSESSIONREQUEST.fields_by_name['model_blob'].containing_oneof = _CREATEMODELSESSIONREQUEST.oneofs_by_name['model']
 _SHAPE.fields_by_name['dims'].message_type = _NAMEDINT
 _SCALE.fields_by_name['scales'].message_type = _NAMEDFLOAT
-_MODELSESSION.fields_by_name['validShapes'].message_type = _SHAPE
+_INPUTSHAPE.fields_by_name['shapeType'].enum_type = _INPUTSHAPE_SHAPETYPE
+_INPUTSHAPE.fields_by_name['shape'].message_type = _SHAPE
+_INPUTSHAPE.fields_by_name['stepShape'].message_type = _SHAPE
+_INPUTSHAPE_SHAPETYPE.containing_type = _INPUTSHAPE
+_MODELSESSION.fields_by_name['inputShapes'].message_type = _INPUTSHAPE
 _MODELSESSION.fields_by_name['halos'].message_type = _SHAPE
 _MODELSESSION.fields_by_name['scales'].message_type = _SCALE
 _MODELSESSION.fields_by_name['offsets'].message_type = _SHAPE
@@ -873,6 +948,7 @@ DESCRIPTOR.message_types_by_name['Blob'] = _BLOB
 DESCRIPTOR.message_types_by_name['CreateModelSessionRequest'] = _CREATEMODELSESSIONREQUEST
 DESCRIPTOR.message_types_by_name['Shape'] = _SHAPE
 DESCRIPTOR.message_types_by_name['Scale'] = _SCALE
+DESCRIPTOR.message_types_by_name['InputShape'] = _INPUTSHAPE
 DESCRIPTOR.message_types_by_name['ModelSession'] = _MODELSESSION
 DESCRIPTOR.message_types_by_name['LogEntry'] = _LOGENTRY
 DESCRIPTOR.message_types_by_name['Devices'] = _DEVICES
@@ -934,6 +1010,13 @@ Scale = _reflection.GeneratedProtocolMessageType('Scale', (_message.Message,), {
   # @@protoc_insertion_point(class_scope:Scale)
   })
 _sym_db.RegisterMessage(Scale)
+
+InputShape = _reflection.GeneratedProtocolMessageType('InputShape', (_message.Message,), {
+  'DESCRIPTOR' : _INPUTSHAPE,
+  '__module__' : 'inference_pb2'
+  # @@protoc_insertion_point(class_scope:InputShape)
+  })
+_sym_db.RegisterMessage(InputShape)
 
 ModelSession = _reflection.GeneratedProtocolMessageType('ModelSession', (_message.Message,), {
   'DESCRIPTOR' : _MODELSESSION,
@@ -1021,8 +1104,8 @@ _INFERENCE = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=1274,
-  serialized_end=1600,
+  serialized_start=1431,
+  serialized_end=1757,
   methods=[
   _descriptor.MethodDescriptor(
     name='CreateModelSession',
@@ -1097,8 +1180,8 @@ _FLIGHTCONTROL = _descriptor.ServiceDescriptor(
   index=1,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=1602,
-  serialized_end=1673,
+  serialized_start=1759,
+  serialized_end=1830,
   methods=[
   _descriptor.MethodDescriptor(
     name='Ping',

--- a/tiktorch/proto/inference_pb2.py
+++ b/tiktorch/proto/inference_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0finference.proto\"Y\n\x06\x44\x65vice\x12\n\n\x02id\x18\x01 \x01(\t\x12\x1e\n\x06status\x18\x02 \x01(\x0e\x32\x0e.Device.Status\"#\n\x06Status\x12\r\n\tAVAILABLE\x10\x00\x12\n\n\x06IN_USE\x10\x01\"W\n\x1f\x43reateDatasetDescriptionRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x0c\n\x04mean\x18\x03 \x01(\x01\x12\x0e\n\x06stddev\x18\x04 \x01(\x01\" \n\x12\x44\x61tasetDescription\x12\n\n\x02id\x18\x01 \x01(\t\"\'\n\x04\x42lob\x12\x0e\n\x06\x66ormat\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\"i\n\x19\x43reateModelSessionRequest\x12\x13\n\tmodel_uri\x18\x01 \x01(\tH\x00\x12\x1b\n\nmodel_blob\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x12\x11\n\tdeviceIds\x18\x05 \x03(\tB\x07\n\x05model\" \n\x05Shape\x12\x17\n\x04\x64ims\x18\x01 \x03(\x0b\x32\t.NamedInt\"$\n\x05Scale\x12\x1b\n\x06scales\x18\x01 \x03(\x0b\x32\x0b.NamedFloat\"\x95\x01\n\nInputShape\x12(\n\tshapeType\x18\x01 \x01(\x0e\x32\x15.InputShape.ShapeType\x12\x15\n\x05shape\x18\x02 \x01(\x0b\x32\x06.Shape\x12\x19\n\tstepShape\x18\x04 \x01(\x0b\x32\x06.Shape\"+\n\tShapeType\x12\x0c\n\x08\x45XPLICIT\x10\x00\x12\x10\n\x0cPARAMETRIZED\x10\x01\"\xce\x01\n\x0cModelSession\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tinputAxes\x18\x03 \x03(\t\x12\x12\n\noutputAxes\x18\x04 \x03(\t\x12\x13\n\x0bhasTraining\x18\x05 \x01(\x08\x12 \n\x0binputShapes\x18\x06 \x03(\x0b\x32\x0b.InputShape\x12\x15\n\x05halos\x18\x07 \x03(\x0b\x32\x06.Shape\x12\x16\n\x06scales\x18\x08 \x03(\x0b\x32\x06.Scale\x12\x17\n\x07offsets\x18\t \x03(\x0b\x32\x06.Shape\"\x9e\x01\n\x08LogEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x1e\n\x05level\x18\x02 \x01(\x0e\x32\x0f.LogEntry.Level\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\t\"N\n\x05Level\x12\n\n\x06NOTSET\x10\x00\x12\t\n\x05\x44\x45\x42UG\x10\x01\x12\x08\n\x04INFO\x10\x02\x12\x0b\n\x07WARNING\x10\x03\x12\t\n\x05\x45RROR\x10\x04\x12\x0c\n\x08\x43RITICAL\x10\x05\"#\n\x07\x44\x65vices\x12\x18\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x07.Device\"&\n\x08NamedInt\x12\x0c\n\x04size\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\"(\n\nNamedFloat\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04name\x18\x02 \x01(\t\"A\n\x06Tensor\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05\x64type\x18\x02 \x01(\t\x12\x18\n\x05shape\x18\x03 \x03(\x0b\x32\t.NamedInt\"U\n\x0ePredictRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x11\n\tdatasetId\x18\x02 \x01(\t\x12\x18\n\x07tensors\x18\x03 \x03(\x0b\x32\x07.Tensor\"+\n\x0fPredictResponse\x12\x18\n\x07tensors\x18\x01 \x03(\x0b\x32\x07.Tensor\"\x07\n\x05\x45mpty\"\x1e\n\tModelInfo\x12\x11\n\tdeviceIds\x18\x01 \x03(\t\"^\n CreateModelSessionChunkedRequest\x12\x1a\n\x04info\x18\x01 \x01(\x0b\x32\n.ModelInfoH\x00\x12\x16\n\x05\x63hunk\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x42\x06\n\x04\x64\x61ta2\xc6\x02\n\tInference\x12\x41\n\x12\x43reateModelSession\x12\x1a.CreateModelSessionRequest\x1a\r.ModelSession\"\x00\x12,\n\x11\x43loseModelSession\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12S\n\x18\x43reateDatasetDescription\x12 .CreateDatasetDescriptionRequest\x1a\x13.DatasetDescription\"\x00\x12 \n\x07GetLogs\x12\x06.Empty\x1a\t.LogEntry\"\x00\x30\x01\x12!\n\x0bListDevices\x12\x06.Empty\x1a\x08.Devices\"\x00\x12.\n\x07Predict\x12\x0f.PredictRequest\x1a\x10.PredictResponse\"\x00\x32G\n\rFlightControl\x12\x18\n\x04Ping\x12\x06.Empty\x1a\x06.Empty\"\x00\x12\x1c\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\"\x00\x62\x06proto3'
+  serialized_pb=b'\n\x0finference.proto\"Y\n\x06\x44\x65vice\x12\n\n\x02id\x18\x01 \x01(\t\x12\x1e\n\x06status\x18\x02 \x01(\x0e\x32\x0e.Device.Status\"#\n\x06Status\x12\r\n\tAVAILABLE\x10\x00\x12\n\n\x06IN_USE\x10\x01\"W\n\x1f\x43reateDatasetDescriptionRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x0c\n\x04mean\x18\x03 \x01(\x01\x12\x0e\n\x06stddev\x18\x04 \x01(\x01\" \n\x12\x44\x61tasetDescription\x12\n\n\x02id\x18\x01 \x01(\t\"\'\n\x04\x42lob\x12\x0e\n\x06\x66ormat\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontent\x18\x02 \x01(\x0c\"i\n\x19\x43reateModelSessionRequest\x12\x13\n\tmodel_uri\x18\x01 \x01(\tH\x00\x12\x1b\n\nmodel_blob\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x12\x11\n\tdeviceIds\x18\x05 \x03(\tB\x07\n\x05model\" \n\x05Shape\x12\x17\n\x04\x64ims\x18\x01 \x03(\x0b\x32\t.NamedInt\"$\n\x05Scale\x12\x1b\n\x06scales\x18\x01 \x03(\x0b\x32\x0b.NamedFloat\"\x95\x01\n\nInputShape\x12(\n\tshapeType\x18\x01 \x01(\x0e\x32\x15.InputShape.ShapeType\x12\x15\n\x05shape\x18\x02 \x01(\x0b\x32\x06.Shape\x12\x19\n\tstepShape\x18\x04 \x01(\x0b\x32\x06.Shape\"+\n\tShapeType\x12\x0c\n\x08\x45XPLICIT\x10\x00\x12\x10\n\x0cPARAMETRIZED\x10\x01\"\xd6\x01\n\x0bOutputShape\x12)\n\tshapeType\x18\x01 \x01(\x0e\x32\x16.OutputShape.ShapeType\x12\x15\n\x05shape\x18\x02 \x01(\x0b\x32\x06.Shape\x12\x14\n\x04halo\x18\x03 \x01(\x0b\x32\x06.Shape\x12\x17\n\x0freferenceTensor\x18\x04 \x01(\t\x12\x15\n\x05scale\x18\x05 \x01(\x0b\x32\x06.Scale\x12\x16\n\x06offset\x18\x06 \x01(\x0b\x32\x06.Shape\"\'\n\tShapeType\x12\x0c\n\x08\x45XPLICIT\x10\x00\x12\x0c\n\x08IMPLICIT\x10\x01\"\xaa\x01\n\x0cModelSession\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x11\n\tinputAxes\x18\x03 \x03(\t\x12\x12\n\noutputAxes\x18\x04 \x03(\t\x12\x13\n\x0bhasTraining\x18\x05 \x01(\x08\x12 \n\x0binputShapes\x18\x06 \x03(\x0b\x32\x0b.InputShape\x12\"\n\x0coutputShapes\x18\x07 \x03(\x0b\x32\x0c.OutputShape\"\x9e\x01\n\x08LogEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\r\x12\x1e\n\x05level\x18\x02 \x01(\x0e\x32\x0f.LogEntry.Level\x12\x0f\n\x07\x63ontent\x18\x03 \x01(\t\"N\n\x05Level\x12\n\n\x06NOTSET\x10\x00\x12\t\n\x05\x44\x45\x42UG\x10\x01\x12\x08\n\x04INFO\x10\x02\x12\x0b\n\x07WARNING\x10\x03\x12\t\n\x05\x45RROR\x10\x04\x12\x0c\n\x08\x43RITICAL\x10\x05\"#\n\x07\x44\x65vices\x12\x18\n\x07\x64\x65vices\x18\x01 \x03(\x0b\x32\x07.Device\"&\n\x08NamedInt\x12\x0c\n\x04size\x18\x01 \x01(\r\x12\x0c\n\x04name\x18\x02 \x01(\t\"(\n\nNamedFloat\x12\x0c\n\x04size\x18\x01 \x01(\x02\x12\x0c\n\x04name\x18\x02 \x01(\t\"A\n\x06Tensor\x12\x0e\n\x06\x62uffer\x18\x01 \x01(\x0c\x12\r\n\x05\x64type\x18\x02 \x01(\t\x12\x18\n\x05shape\x18\x03 \x03(\x0b\x32\t.NamedInt\"U\n\x0ePredictRequest\x12\x16\n\x0emodelSessionId\x18\x01 \x01(\t\x12\x11\n\tdatasetId\x18\x02 \x01(\t\x12\x18\n\x07tensors\x18\x03 \x03(\x0b\x32\x07.Tensor\"+\n\x0fPredictResponse\x12\x18\n\x07tensors\x18\x01 \x03(\x0b\x32\x07.Tensor\"\x07\n\x05\x45mpty\"\x1e\n\tModelInfo\x12\x11\n\tdeviceIds\x18\x01 \x03(\t\"^\n CreateModelSessionChunkedRequest\x12\x1a\n\x04info\x18\x01 \x01(\x0b\x32\n.ModelInfoH\x00\x12\x16\n\x05\x63hunk\x18\x02 \x01(\x0b\x32\x05.BlobH\x00\x42\x06\n\x04\x64\x61ta2\xc6\x02\n\tInference\x12\x41\n\x12\x43reateModelSession\x12\x1a.CreateModelSessionRequest\x1a\r.ModelSession\"\x00\x12,\n\x11\x43loseModelSession\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12S\n\x18\x43reateDatasetDescription\x12 .CreateDatasetDescriptionRequest\x1a\x13.DatasetDescription\"\x00\x12 \n\x07GetLogs\x12\x06.Empty\x1a\t.LogEntry\"\x00\x30\x01\x12!\n\x0bListDevices\x12\x06.Empty\x1a\x08.Devices\"\x00\x12.\n\x07Predict\x12\x0f.PredictRequest\x1a\x10.PredictResponse\"\x00\x32G\n\rFlightControl\x12\x18\n\x04Ping\x12\x06.Empty\x1a\x06.Empty\"\x00\x12\x1c\n\x08Shutdown\x12\x06.Empty\x1a\x06.Empty\"\x00\x62\x06proto3'
 )
 
 
@@ -74,6 +74,31 @@ _INPUTSHAPE_SHAPETYPE = _descriptor.EnumDescriptor(
 )
 _sym_db.RegisterEnumDescriptor(_INPUTSHAPE_SHAPETYPE)
 
+_OUTPUTSHAPE_SHAPETYPE = _descriptor.EnumDescriptor(
+  name='ShapeType',
+  full_name='OutputShape.ShapeType',
+  filename=None,
+  file=DESCRIPTOR,
+  create_key=_descriptor._internal_create_key,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='EXPLICIT', index=0, number=0,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+    _descriptor.EnumValueDescriptor(
+      name='IMPLICIT', index=1, number=1,
+      serialized_options=None,
+      type=None,
+      create_key=_descriptor._internal_create_key),
+  ],
+  containing_type=None,
+  serialized_options=None,
+  serialized_start=781,
+  serialized_end=820,
+)
+_sym_db.RegisterEnumDescriptor(_OUTPUTSHAPE_SHAPETYPE)
+
 _LOGENTRY_LEVEL = _descriptor.EnumDescriptor(
   name='Level',
   full_name='LogEntry.Level',
@@ -114,8 +139,8 @@ _LOGENTRY_LEVEL = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=895,
-  serialized_end=973,
+  serialized_start=1076,
+  serialized_end=1154,
 )
 _sym_db.RegisterEnumDescriptor(_LOGENTRY_LEVEL)
 
@@ -439,6 +464,74 @@ _INPUTSHAPE = _descriptor.Descriptor(
 )
 
 
+_OUTPUTSHAPE = _descriptor.Descriptor(
+  name='OutputShape',
+  full_name='OutputShape',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='shapeType', full_name='OutputShape.shapeType', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='shape', full_name='OutputShape.shape', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='halo', full_name='OutputShape.halo', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='referenceTensor', full_name='OutputShape.referenceTensor', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='scale', full_name='OutputShape.scale', index=4,
+      number=5, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='offset', full_name='OutputShape.offset', index=5,
+      number=6, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _OUTPUTSHAPE_SHAPETYPE,
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=606,
+  serialized_end=820,
+)
+
+
 _MODELSESSION = _descriptor.Descriptor(
   name='ModelSession',
   full_name='ModelSession',
@@ -490,22 +583,8 @@ _MODELSESSION = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='halos', full_name='ModelSession.halos', index=6,
+      name='outputShapes', full_name='ModelSession.outputShapes', index=6,
       number=7, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='scales', full_name='ModelSession.scales', index=7,
-      number=8, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='offsets', full_name='ModelSession.offsets', index=8,
-      number=9, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -522,8 +601,8 @@ _MODELSESSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=606,
-  serialized_end=812,
+  serialized_start=823,
+  serialized_end=993,
 )
 
 
@@ -569,8 +648,8 @@ _LOGENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=815,
-  serialized_end=973,
+  serialized_start=996,
+  serialized_end=1154,
 )
 
 
@@ -601,8 +680,8 @@ _DEVICES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=975,
-  serialized_end=1010,
+  serialized_start=1156,
+  serialized_end=1191,
 )
 
 
@@ -640,8 +719,8 @@ _NAMEDINT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1012,
-  serialized_end=1050,
+  serialized_start=1193,
+  serialized_end=1231,
 )
 
 
@@ -679,8 +758,8 @@ _NAMEDFLOAT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1052,
-  serialized_end=1092,
+  serialized_start=1233,
+  serialized_end=1273,
 )
 
 
@@ -725,8 +804,8 @@ _TENSOR = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1094,
-  serialized_end=1159,
+  serialized_start=1275,
+  serialized_end=1340,
 )
 
 
@@ -771,8 +850,8 @@ _PREDICTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1161,
-  serialized_end=1246,
+  serialized_start=1342,
+  serialized_end=1427,
 )
 
 
@@ -803,8 +882,8 @@ _PREDICTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1248,
-  serialized_end=1291,
+  serialized_start=1429,
+  serialized_end=1472,
 )
 
 
@@ -828,8 +907,8 @@ _EMPTY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1293,
-  serialized_end=1300,
+  serialized_start=1474,
+  serialized_end=1481,
 )
 
 
@@ -860,8 +939,8 @@ _MODELINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1302,
-  serialized_end=1332,
+  serialized_start=1483,
+  serialized_end=1513,
 )
 
 
@@ -904,8 +983,8 @@ _CREATEMODELSESSIONCHUNKEDREQUEST = _descriptor.Descriptor(
       create_key=_descriptor._internal_create_key,
     fields=[]),
   ],
-  serialized_start=1334,
-  serialized_end=1428,
+  serialized_start=1515,
+  serialized_end=1609,
 )
 
 _DEVICE.fields_by_name['status'].enum_type = _DEVICE_STATUS
@@ -923,10 +1002,14 @@ _INPUTSHAPE.fields_by_name['shapeType'].enum_type = _INPUTSHAPE_SHAPETYPE
 _INPUTSHAPE.fields_by_name['shape'].message_type = _SHAPE
 _INPUTSHAPE.fields_by_name['stepShape'].message_type = _SHAPE
 _INPUTSHAPE_SHAPETYPE.containing_type = _INPUTSHAPE
+_OUTPUTSHAPE.fields_by_name['shapeType'].enum_type = _OUTPUTSHAPE_SHAPETYPE
+_OUTPUTSHAPE.fields_by_name['shape'].message_type = _SHAPE
+_OUTPUTSHAPE.fields_by_name['halo'].message_type = _SHAPE
+_OUTPUTSHAPE.fields_by_name['scale'].message_type = _SCALE
+_OUTPUTSHAPE.fields_by_name['offset'].message_type = _SHAPE
+_OUTPUTSHAPE_SHAPETYPE.containing_type = _OUTPUTSHAPE
 _MODELSESSION.fields_by_name['inputShapes'].message_type = _INPUTSHAPE
-_MODELSESSION.fields_by_name['halos'].message_type = _SHAPE
-_MODELSESSION.fields_by_name['scales'].message_type = _SCALE
-_MODELSESSION.fields_by_name['offsets'].message_type = _SHAPE
+_MODELSESSION.fields_by_name['outputShapes'].message_type = _OUTPUTSHAPE
 _LOGENTRY.fields_by_name['level'].enum_type = _LOGENTRY_LEVEL
 _LOGENTRY_LEVEL.containing_type = _LOGENTRY
 _DEVICES.fields_by_name['devices'].message_type = _DEVICE
@@ -949,6 +1032,7 @@ DESCRIPTOR.message_types_by_name['CreateModelSessionRequest'] = _CREATEMODELSESS
 DESCRIPTOR.message_types_by_name['Shape'] = _SHAPE
 DESCRIPTOR.message_types_by_name['Scale'] = _SCALE
 DESCRIPTOR.message_types_by_name['InputShape'] = _INPUTSHAPE
+DESCRIPTOR.message_types_by_name['OutputShape'] = _OUTPUTSHAPE
 DESCRIPTOR.message_types_by_name['ModelSession'] = _MODELSESSION
 DESCRIPTOR.message_types_by_name['LogEntry'] = _LOGENTRY
 DESCRIPTOR.message_types_by_name['Devices'] = _DEVICES
@@ -1017,6 +1101,13 @@ InputShape = _reflection.GeneratedProtocolMessageType('InputShape', (_message.Me
   # @@protoc_insertion_point(class_scope:InputShape)
   })
 _sym_db.RegisterMessage(InputShape)
+
+OutputShape = _reflection.GeneratedProtocolMessageType('OutputShape', (_message.Message,), {
+  'DESCRIPTOR' : _OUTPUTSHAPE,
+  '__module__' : 'inference_pb2'
+  # @@protoc_insertion_point(class_scope:OutputShape)
+  })
+_sym_db.RegisterMessage(OutputShape)
 
 ModelSession = _reflection.GeneratedProtocolMessageType('ModelSession', (_message.Message,), {
   'DESCRIPTOR' : _MODELSESSION,
@@ -1104,8 +1195,8 @@ _INFERENCE = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=1431,
-  serialized_end=1757,
+  serialized_start=1612,
+  serialized_end=1938,
   methods=[
   _descriptor.MethodDescriptor(
     name='CreateModelSession',
@@ -1180,8 +1271,8 @@ _FLIGHTCONTROL = _descriptor.ServiceDescriptor(
   index=1,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=1759,
-  serialized_end=1830,
+  serialized_start=1940,
+  serialized_end=2011,
   methods=[
   _descriptor.MethodDescriptor(
     name='Ping',

--- a/tiktorch/server/grpc/inference_servicer.py
+++ b/tiktorch/server/grpc/inference_servicer.py
@@ -48,9 +48,7 @@ class InferenceServicer(inference_pb2_grpc.InferenceServicer):
             raise
 
         pb_input_shapes = [converters.input_shape_to_pb_input_shape(shape) for shape in model_info.input_shapes]
-        pb_halos = [converters.name_int_tuples_to_pb_shape(halo) for halo in model_info.halos]
-        pb_offsets = [converters.name_int_tuples_to_pb_shape(offset) for offset in model_info.offsets]
-        pb_valid_scales = [converters.name_float_tuples_to_pb_scale(scale) for scale in model_info.scales]
+        pb_output_shapes = [converters.output_shape_to_pb_output_shape(shape) for shape in model_info.output_shapes]
 
         return inference_pb2.ModelSession(
             id=session.id,
@@ -59,9 +57,7 @@ class InferenceServicer(inference_pb2_grpc.InferenceServicer):
             outputAxes=model_info.output_axes,
             inputShapes=pb_input_shapes,
             hasTraining=False,
-            halos=pb_halos,
-            scales=pb_valid_scales,
-            offsets=pb_offsets,
+            outputShapes=pb_output_shapes,
         )
 
     def CreateDatasetDescription(

--- a/tiktorch/server/grpc/inference_servicer.py
+++ b/tiktorch/server/grpc/inference_servicer.py
@@ -47,14 +47,7 @@ class InferenceServicer(inference_pb2_grpc.InferenceServicer):
             lease.terminate()
             raise
 
-        pb_valid_shapes = []
-        for shape in model_info.valid_shapes:
-            pb_shape = []
-            for tag, size in shape:
-                pb_shape.append(inference_pb2.NamedInt(size=size, name=tag))
-
-            pb_valid_shapes.append(inference_pb2.Shape(dims=pb_shape))
-
+        pb_input_shapes = [converters.input_shape_to_pb_input_shape(shape) for shape in model_info.input_shapes]
         pb_halos = [converters.name_int_tuples_to_pb_shape(halo) for halo in model_info.halos]
         pb_offsets = [converters.name_int_tuples_to_pb_shape(offset) for offset in model_info.offsets]
         pb_valid_scales = [converters.name_float_tuples_to_pb_scale(scale) for scale in model_info.scales]
@@ -64,7 +57,7 @@ class InferenceServicer(inference_pb2_grpc.InferenceServicer):
             name=model_info.name,
             inputAxes=model_info.input_axes,
             outputAxes=model_info.output_axes,
-            validShapes=pb_valid_shapes,
+            inputShapes=pb_input_shapes,
             hasTraining=False,
             halos=pb_halos,
             scales=pb_valid_scales,


### PR DESCRIPTION
Tiktorch can now handle Explicit/Parametrized input shape, as well as Explicit/Implicit Output shapes

Summary:

* added support for `ParametrizedInputShape`.
* Added support for `ImplicitOutputShape`
* renamed `valid_shapes` -> `input_shapes`
* backwards-incompatible changes to protos!

Todos:

* [x] add tests
