### PR TITLE
move type definitions to converters

### DIFF
--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -4,15 +4,17 @@ import xarray as xr
 from numpy.testing import assert_array_equal
 
 from tiktorch.converters import (
+    NamedExplicitOutputShape,
+    NamedImplicitOutputShape,
+    NamedParametrizedShape,
+    input_shape_to_pb_input_shape,
     numpy_to_pb_tensor,
+    output_shape_to_pb_output_shape,
     pb_tensor_to_numpy,
     pb_tensor_to_xarray,
     xarray_to_pb_tensor,
-    output_shape_to_pb_output_shape,
-    input_shape_to_pb_input_shape,
 )
 from tiktorch.proto import inference_pb2
-from tiktorch.server.session.process import NamedImplicitOutputShape, NamedParametrizedShape, NamedExplicitOutputShape
 
 
 def _numpy_to_pb_tensor(arr):

--- a/tiktorch/converters.py
+++ b/tiktorch/converters.py
@@ -1,15 +1,36 @@
-from typing import Union
+import dataclasses
+from typing import List, Tuple, Union
 
 import numpy as np
 import xarray as xr
 
 from tiktorch.proto import inference_pb2
-from tiktorch.server.session.process import (
-    NamedExplicitOutputShape,
-    NamedImplicitOutputShape,
-    NamedParametrizedShape,
-    NamedShape,
-)
+
+# pairs of axis-shape for a single tensor
+NamedInt = Tuple[str, int]
+NamedFloat = Tuple[str, float]
+NamedShape = List[NamedInt]
+NamedVec = List[NamedFloat]
+
+
+@dataclasses.dataclass
+class NamedParametrizedShape:
+    min_shape: NamedShape
+    step_shape: NamedShape
+
+
+@dataclasses.dataclass
+class NamedExplicitOutputShape:
+    shape: NamedShape
+    halo: NamedShape
+
+
+@dataclasses.dataclass
+class NamedImplicitOutputShape:
+    reference_tensor: str
+    offset: NamedShape
+    scale: NamedVec
+    halo: NamedShape
 
 
 def numpy_to_pb_tensor(array: np.ndarray, axistags=None) -> inference_pb2.Tensor:

--- a/tiktorch/server/session/process.py
+++ b/tiktorch/server/session/process.py
@@ -14,38 +14,13 @@ from bioimageio.core.prediction_pipeline import PredictionPipeline, create_predi
 from bioimageio.spec.shared.raw_nodes import ImplicitOutputShape, ParametrizedInputShape
 
 from tiktorch import log
+from tiktorch.converters import NamedExplicitOutputShape, NamedImplicitOutputShape, NamedParametrizedShape, NamedShape
 from tiktorch.rpc import Shutdown
 from tiktorch.rpc import mp as _mp_rpc
 from tiktorch.rpc.mp import MPServer
 
 from .backend import base
 from .rpc_interface import IRPCModelSession
-
-# pairs of axis-shape for a single tensor
-NamedInt = Tuple[str, int]
-NamedFloat = Tuple[str, float]
-NamedShape = List[NamedInt]
-NamedVec = List[NamedFloat]
-
-
-@dataclasses.dataclass
-class NamedParametrizedShape:
-    min_shape: NamedShape
-    step_shape: NamedShape
-
-
-@dataclasses.dataclass
-class NamedExplicitOutputShape:
-    shape: NamedShape
-    halo: NamedShape
-
-
-@dataclasses.dataclass
-class NamedImplicitOutputShape:
-    reference_tensor: str
-    offset: NamedShape
-    scale: NamedVec
-    halo: NamedShape
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Totally my fault.

Admittedly it felt wrong when I imported from process into the converters. Turns
out this will trigger configuration of logging and mess with other libraries.