### PR TITLE
installation docs updated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,8 +162,6 @@ workflows:
           requires:
             - install_conda_env
       - build_conda_packages:
-          requires:
-            - install_conda_env
           context: conda-upload
           filters:
             tags:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,46 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Conda](https://anaconda.org/ilastik-forge/tiktorch/badges/version.svg)](https://anaconda.org/ilastik-forge/tiktorch)
 
-## Prerequisites
+`tiktorch` is the neural network prediction server for [`ilastik`](https://ilastik.org).
+The server is used in the [Neural Network Workflow](https://www.ilastik.org/documentation/nn/nn).
+In short, this workflow allows you to grab a network from the [bioimage.io Model Zoo](https://bioimage.io/#/?partner=ilastik) and run it on your data.
+If you don't have access to a machine with a GPU, then you can still run your networks on your local CPU.
+This can be slow, depending on the network and the data (usually 3D networks will be _very_ slow).
+If you have an nvidia GPU on the machine you are running ilastik on, then you don't need to install this component separately.
+Instead, make sure to pick a `-gpu` enabled [binary of ilastik](https://www.ilastik.org/download.html#beta) and you should be ready to go.
+
+Reasons to install the server component:
+ * you have access to a powerful machine with nvidia GPUs, but want to run ilastik on your laptop
+ * you want to run `tensorflow` networks (as of now, ilastik does not include `tensorflow` runtime)
+
+We have a how-to for the set up of a tiktorch prediction server (powerful machine with nvidia GPU) to connect to from your client (e.g. ilastik on a laptop): [Installation](#installation).
+
+If you are interested in running Model Zoo networks from Python directly, have a look at [`bioimageio.core`](https://github.com/bioimage-io/core-bioimage-io-python), where we have an [example notebook](https://github.com/bioimage-io/core-bioimage-io-python/blob/main/example/bioimageio-core-usage.ipynb) to get you started.
+
+
+## Installation
+
+The tiktorch package let's you add the network dependencies you need.
+E.g. in order to install the `tiktorch` server to run `pytorch` networks via
+ilastik, you'd add `pytorch` (and optionally also specify `cuda` version):
+
+```
+conda create --strict-channel-priority --name tiktorch-server-env -c pytorch -c ilastik-forge -c conda-forge tiktorch pytorch cudatoolkit>=11.2
+
+conda activate tiktorch-server-env
+```
+To run server locally use
+```
+tiktorch-server
+```
+To be able to connect to remote machine use (this will bind to all available addresses)
+```
+tiktorch-server --addr 0.0.0.0
+```
+
+## Development environment
+
+### Prerequisites
 
 This repository uses git submodules rather than conda dependencies for some libraries that are quickly evolving.
 In order to work with this repository, these need to be properly initialized and updated.
@@ -19,24 +58,7 @@ git submodule update
 
 ```
 
-
-## Installation
-To install tiktorch and start server run:
-```
-conda create --strict-channel-priority --name tiktorch-server-env -c pytorch -c ilastik-forge -c conda-forge tiktorch
-
-conda activate tiktorch-server-env
-```
-To run server locally use
-```
-tiktorch-server
-```
-To be able to connect to remote machine use (this will bind to all available addresses)
-```
-tiktorch-server --addr 0.0.0.0
-```
-
-## Development environment
+### Create the development environment
 
 To create development environment run:
 


### PR DESCRIPTION
I tried to make the docs here a little more user friendly, specifically,

* I tried to outline, when one would install the tiktorch server (and also, when not to do it).
* I wanted to also advertise `bioimageio.core` for direct Python usage