### PR TITLE
update/unpin/enable python37/38/39

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,8 @@ jobs:
           command: |
             . /opt/conda/etc/profile.d/conda.sh
             conda activate tiktorch-server-env
-            python -m pytest
+            conda list
+            python -m pytest -v
 
   isort:
     docker:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - python >=3.7,<3.10
   run:
     - python >=3.7,<3.10
+    - pickle5  # [py37]
     {% for dep in setup_py_data['install_requires'] %}
     - {{ dep.lower() }}
     {% endfor %}

--- a/environment.yml
+++ b/environment.yml
@@ -1,30 +1,27 @@
 name: tiktorch-server-env
 channels:
-  - ilastik-forge
+  - ilastik-forge/label/freepy
   - pytorch
   - conda-forge
-  - defaults
 dependencies:
   # - bioimage.spec via submodule
   # - bioimage.core via submodule
   - lapack
   - mypy
   - flake8
-  - pickle5
-  - python=3.7.*
-  - scipy=1.2.*  # 1.3 removed imsave
-  - paramiko=2.4.2
+  - python=3.8.*
+  - scipy
   - ruamel.yaml
   - inferno=v0.4.*
-  - pillow=6.2.1
   - pyyaml=5.3
   - marshmallow=3.12.*
-  - pytest=4.3.0
+  - pytest
   - grpcio-tools
   - xarray>=0.16
+  - pytorch>=1.6
   - protobuf
-  - cudatoolkit>=10.1,<10.2
-  - numpy=1.18.5
+  - cudatoolkit>=10.1,<11.2
+  - numpy=1.19.*
   - cudnn
   - black
   - isort
@@ -34,7 +31,6 @@ dependencies:
   - pre_commit
   - scikit-learn
   - marshmallow-union
-  - git
   - typing-extensions
   # pinned dependencies to avoid unistallations by pip:
   - h5py<=3.1.0
@@ -43,8 +39,4 @@ dependencies:
   - grpcio>=1.31,<=1.40.0
   - pytorch
   - cpuonly
-
-  - pip:
-  #     - onnxruntime
-      - pytest-grpc==0.7.0
-  #     - tensorflow
+  - pytest-grpc

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - lapack
   - mypy
   - flake8
-  - python=3.8.*
+  - python=3.9.*
   - scipy
   - ruamel.yaml
   - inferno=v0.4.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ line_length = 120
 multi_line_output = 3
 include_trailing_comma = true
 known_first_party = tiktorch
-known_third_party = inferno,torch,numpy,zmq,paramiko
+known_third_party = inferno,torch,numpy,zmq
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 skip = tiktorch/proto,scripts,vendor
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="tiktorch",
-    version="21.11.1",
+    version="21.11.2",
     description="Tiktorch client/server",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,6 @@ setup(
         "grpcio-tools",
         "grpcio>=1.31",
         "numpy",
-        "paramiko",
-        "pickle5",
         "protobuf",
         "pyyaml",
         "xarray",

--- a/tests/test_rpc/test_mp.py
+++ b/tests/test_rpc/test_mp.py
@@ -156,9 +156,6 @@ class ICancelable(RPCInterface):
         return Shutdown()
 
 
-cancelled = object()
-
-
 class CancelledExecutor:
     def __init__(self):
         self._q = queue.Queue()
@@ -192,7 +189,6 @@ class CancelledExecutor:
 
             try:
                 if fut.cancelled():
-                    fut.set_result(cancelled)
                     self.cancelled_count += 1
                 else:
                     res = task()
@@ -231,7 +227,8 @@ def test_canceled_executor():
     executor.process_queued()
 
     assert f.result(timeout=1) == 42
-    assert f2.result(timeout=1) is cancelled
+    with pytest.raises(CancelledError):
+        assert f2.result(timeout=1)
     assert executor.cancelled_count == 1
 
     executor.stop()

--- a/tests/test_rpc/test_types.py
+++ b/tests/test_rpc/test_types.py
@@ -70,7 +70,6 @@ def test_propagates_only_once_1():
 
     rpc_fut.attach(fut)
     rpc_fut.cancel()
-    rpc_fut.set_result(42)
 
     with pytest.raises(CancelledError):
         assert fut.result(timeout=1)

--- a/tests/test_server/test_datasets.py
+++ b/tests/test_server/test_datasets.py
@@ -1,4 +1,5 @@
 import math
+import os
 from collections import Counter
 
 import numpy as np
@@ -128,6 +129,9 @@ class TestDynamicWeightedRandomSampler:
         sample_idx = next(iter(sampler))
         assert sample_idx == 2
 
+    @pytest.mark.skipif(
+        os.environ.get("CIRCLECI", "") == "true", reason="For some unknown reason this test hangs on circleci"
+    )
     def test_distribution(self):
         ds = self.DatasetStub(torch.Tensor([0.1, 0.2, 0.7]))
         num_samples = 10_000

--- a/tiktorch/rpc/interface.py
+++ b/tiktorch/rpc/interface.py
@@ -19,6 +19,7 @@ class RPCInterface(metaclass=RPCInterfaceMeta):
 
 
 def exposed(method: Callable[..., Any]) -> Callable[..., Any]:
+    """decorator to mark method as exposed in the public API of the class"""
     method.__exposed__ = True
     return method
 


### PR DESCRIPTION
Make sure that this package works with python versions 3.7, 3.8, 3.9

Summary:
* updated the dev environment to use Python39
* fixed tests that failed with Python>37
* one test is now skipped on CI as it would hang (see #195)