### PR TITLE
Fix dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             - /opt/conda/envs
           key: v11-dependencies-{{ checksum "environment.yml" }}
 
-  black_check:
+  pre_commit_check:
     docker:
       - image: condaforge/mambaforge
     working_directory: ~/repo
@@ -55,30 +55,11 @@ jobs:
             - v11-dependencies-{{ checksum "environment.yml" }}
 
       - run:
-          name: run black
+          name: run pre-commit
           command: |
             . /opt/conda/etc/profile.d/conda.sh
             conda activate tiktorch-server-env
-            black --check ./
-
-  flake8_check:
-    docker:
-      - image: condaforge/mambaforge
-    working_directory: ~/repo
-    steps:
-      - restore_cache:
-          keys:
-            - v1-repo-{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          keys:
-            - v11-dependencies-{{ checksum "environment.yml" }}
-
-      - run:
-          name: run flake8
-          command: |
-            . /opt/conda/etc/profile.d/conda.sh
-            conda activate tiktorch-server-env
-            flake8 .
+            pre-commit run --from-ref origin/${CIRCLE_BRANCH} --to-ref ${CIRCLE_BRANCH}
 
   tests:
     docker:
@@ -99,25 +80,6 @@ jobs:
             conda activate tiktorch-server-env
             conda list
             python -m pytest -v
-
-  isort:
-    docker:
-      - image: condaforge/mambaforge
-    working_directory: ~/repo
-    steps:
-      - restore_cache:
-          keys:
-            - v1-repo-{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          keys:
-            - v11-dependencies-{{ checksum "environment.yml" }}
-
-      - run:
-          name: run isort
-          command: |
-            . /opt/conda/etc/profile.d/conda.sh
-            conda activate tiktorch-server-env
-            isort --check --conda-env /opt/conda/envs/tiktorch-server-env ./
 
   build_conda_packages:
     docker:
@@ -154,13 +116,7 @@ workflows:
       - tests:
           requires:
             - install_conda_env
-      - isort:
-          requires:
-            - install_conda_env
-      - black_check:
-          requires:
-            - install_conda_env
-      - flake8_check:
+      - pre_commit_check:
           requires:
             - install_conda_env
       - build_conda_packages:

--- a/environment.yml
+++ b/environment.yml
@@ -46,10 +46,7 @@ dependencies:
   - typer
 
   # dev stuff
-  - black
   - bump2version
-  - flake8
-  - isort
   - mypy
   - pre_commit
 

--- a/environment.yml
+++ b/environment.yml
@@ -54,3 +54,5 @@ dependencies:
   - pre_commit
 
   - pip
+
+  - mkl <2024.1.0  # [linux] until pytorch is compatible with the current version


### PR DESCRIPTION
- Restrict mkl dependency as ilastik does in the [env.yml](https://github.com/ilastik/ilastik/blob/main/dev/environment-dev.yml#L85)
- We have declared the dev dependencies of black, isort and flake8 both at the `environment.yaml`, and the `pre-commit` config, and these two are out of sync. I am not sure if we should keep the dev ones or the pre-commit ones. A problematic use case is the CI checks that pulls the packages from `environment.yaml`, and a developer using the `pre-commit` hooks with different versions.