### PR TITLE
Fix pre-commit ci action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,13 +26,16 @@ jobs:
           environment-file: environment.yml
           channel-priority: flexible
           miniforge-variant: Miniforge3
+      - name: Get the latest commit hash and target ref
+        run: |
+          echo "COMMIT_HASH=$(git log -1 --format='%H')" >> $GITHUB_ENV
+          echo "REF=${{ github.event.pull_request.base.ref || github.ref_name }}" >> $GITHUB_ENV
       - name: Run Pre-Commit
         run: |
-          echo $BRANCH_NAME
-          echo ${{ github.event.pull_request.base.ref }}
-          echo ${{ github.event.pull_request.head.sha }}
+          echo $REF
+          echo $COMMIT_HASH
           git fetch origin
-          pre-commit run --from-ref origin/${{ github.event.pull_request.base.ref }} --to-ref ${{ github.event.pull_request.head.sha }}
+          pre-commit run --from-ref origin/$REF --to-ref $COMMIT_HASH
 
   test-dev:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Get the latest commit hash and target ref to specify a range for the `pre-commit`. The env can be realized for both pull request and push operations. Previously, it worked only for pull requests, and it will fail when merging a branch.