### PR TITLE
Add pytorch-3dunet dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   # - bioimage.core via submodule
   - python 3.9.*
   - numpy >=1.21,<2
-  - grpcio=1.44 # protobuf 5 requires protoc version > 3.19.0 that requires grpcio >= 1.44
+  - grpcio=1.49.1 # protobuf 5 requires protoc version > 3.19.0 that requires grpcio >= 1.44
   - marshmallow-union
   - marshmallow=3.12.*
   - marshmallow-jsonschema
@@ -20,6 +20,7 @@ dependencies:
   - scipy
   - typing-extensions
   - xarray
+  - pytorch-3dunet
   - setuptools
   - pip
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "numpy<2",  # pytorch 2.2.2-py3.9_0 for macos is compiled with numpy 1.*
         "protobuf",
         "pydantic>=2.7.0,<2.10",
+        "pytorch-3dunet",
         "pyyaml",
         "xarray",
     ],


### PR DESCRIPTION
I created a separate PR just for the dependency, because there is an issue with the grpcio and protobuff.

So, we know for the new protobuff > 5, we need grpico >= 1.44. The `tensorboard` dependency of the `pytorch-3dunet` that can work with protobuff > 5 is the [2.18](https://github.com/tensorflow/tensorboard/releases). For our system, the latest version that conda fetches is the 2.11. 

I have attempted to find a solution by forcing the latest tensorboard version trying a dry run install:
```shell
$ conda install tensorboard=2.18 --dry-run

Could not solve for environment specs
The following packages are incompatible
├─ grpcio 1.44**  is installable with the potential options
│  ├─ grpcio [1.44.0|1.49.1|...|1.67.1] would require
│  │  └─ python >=3.10,<3.11.0a0 , which can be installed;
│  ├─ grpcio [1.44.0|1.49.1|...|1.62.2] would require
│  │  └─ python >=3.8,<3.9.0a0 , which can be installed;
│  ├─ grpcio 1.44.0, which can be installed;
│  └─ grpcio 1.44.0 would require
│     └─ python >=3.7,<3.8.0a0 , which can be installed;
├─ pin-1 is not installable because it requires
│  └─ python 3.9.* , which conflicts with any installable versions previously reported;
└─ tensorboard 2.18**  is installable and it requires
   └─ grpcio >=1.48.2  with the potential options
      ├─ grpcio [1.44.0|1.49.1|...|1.67.1], which can be installed (as previously explained);
      ├─ grpcio [1.49.1|1.50.1|...|1.67.1] would require
      │  └─ python >=3.11,<3.12.0a0 , which can be installed;
      ├─ grpcio [1.44.0|1.49.1|...|1.62.2], which can be installed (as previously explained);
      ├─ grpcio [1.49.1|1.50.1|...|1.67.1] conflicts with any installable versions previously reported;
      ├─ grpcio [1.57.0|1.58.1] would require
      │  └─ python >=3.12.0rc3,<3.13.0a0  with the potential options
      │     ├─ python [3.12.0|3.12.1|...|3.12.8], which can be installed;
      │     └─ python 3.12.0rc3 would require
      │        └─ _python_rc, which does not exist (perhaps a missing channel);
      ├─ grpcio [1.57.0|1.57.1|...|1.67.1] would require
      │  └─ python >=3.12,<3.13.0a0 , which can be installed;
      └─ grpcio [1.67.0|1.67.1] would require
         └─ python >=3.13,<3.14.0a0 , which can be installed.
```

So, we need to either bump python 3.9, or restrict the protobuff. I am not sure how to proceed with this one. For now, I just use the environment variable `PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` to make it work.