### PR TITLE
Add save and export to training servicer

### DIFF
--- a/proto/training.proto
+++ b/proto/training.proto
@@ -21,7 +21,9 @@ service Training {
 
     rpc GetLogs(ModelSession) returns (GetLogsResponse) {}
 
-    rpc Export(ModelSession) returns (Empty) {}
+    rpc Save(SaveRequest) returns (Empty) {}
+
+    rpc Export(ExportRequest) returns (Empty) {}
 
     rpc Predict(PredictRequest) returns (PredictResponse) {}
 
@@ -58,6 +60,17 @@ message GetLogsResponse {
     repeated Logs logs = 1;
 }
 
+
+message SaveRequest {
+    ModelSession modelSessionId = 1;
+    string filePath = 2;
+}
+
+
+message ExportRequest {
+    ModelSession modelSessionId = 1;
+    string filePath = 2;
+}
 
 message ValidationResponse {
     double validation_score_average = 1;

--- a/tests/test_server/test_grpc/test_training_servicer.py
+++ b/tests/test_server/test_grpc/test_training_servicer.py
@@ -2,7 +2,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 import grpc
 import h5py
@@ -41,8 +41,11 @@ def grpc_stub_cls():
     return training_pb2_grpc.TrainingStub
 
 
-def unet2d_config_path(checkpoint_dir, train_data_dir, val_data_path, device: str = "cpu"):
-    return f"""
+def unet2d_config_path(
+    checkpoint_dir: Path, train_data_dir: str, val_data_path: str, resume: Optional[str] = None, device: str = "cpu"
+):
+    # todo: upsampling makes model torchscript incompatible
+    config = f"""
 device: {device}  # Use CPU for faster test execution, change to 'cuda' if GPU is available and necessary
 model:
   name: UNet2D
@@ -53,13 +56,14 @@ model:
   num_groups: 4
   final_sigmoid: false
   is_segmentation: true
+  upsample: default
 trainer:
   checkpoint_dir: {checkpoint_dir}
-  resume: null
-  validate_after_iters: 2
+  resume: {resume if resume else "null"}
+  validate_after_iters: 250
   log_after_iters: 2
-  max_num_epochs: 1000
-  max_num_iterations: 10000
+  max_num_epochs: 10000
+  max_num_iterations: 100000
   eval_score_higher_is_better: True
 optimizer:
   learning_rate: 0.0002
@@ -149,6 +153,7 @@ loaders:
         - name: ToTensor
           expand_dims: false
 """
+    return config
 
 
 def create_random_dataset(shape, channel_per_class):
@@ -171,15 +176,22 @@ def create_random_dataset(shape, channel_per_class):
     return tmp.name
 
 
-def prepare_unet2d_test_environment(device: str = "cpu") -> str:
+def prepare_unet2d_test_environment(resume: Optional[str] = None, device: str = "cpu") -> str:
     checkpoint_dir = Path(tempfile.mkdtemp())
 
-    shape = (3, 1, 128, 128)
+    in_channel = 3
+    z = 1  # 2d
+    y = 128
+    x = 128
+    shape = (in_channel, z, y, x)
     binary_loss = False
     train = create_random_dataset(shape, binary_loss)
     val = create_random_dataset(shape, binary_loss)
 
-    return unet2d_config_path(checkpoint_dir=checkpoint_dir, train_data_dir=train, val_data_path=val, device=device)
+    config = unet2d_config_path(
+        resume=resume, checkpoint_dir=checkpoint_dir, train_data_dir=train, val_data_path=val, device=device
+    )
+    return config
 
 
 class TestTrainingServicer:
@@ -560,6 +572,48 @@ class TestTrainingServicer:
         with pytest.raises(grpc.RpcError) as excinfo:
             grpc_stub.Predict(predict_request)
         assert "Tensor dims should be" in excinfo.value.details()
+
+    def test_save(self, grpc_stub):
+        training_session_id = grpc_stub.Init(
+            training_pb2.TrainingConfig(yaml_content=prepare_unet2d_test_environment())
+        )
+
+        grpc_stub.Start(training_session_id)
+
+        with tempfile.TemporaryDirectory() as model_checkpoint_dir:
+            model_checkpoint_file = Path(model_checkpoint_dir) / "model.pth"
+            save_request = training_pb2.SaveRequest(
+                modelSessionId=training_session_id, filePath=str(model_checkpoint_file)
+            )
+            grpc_stub.Save(save_request)
+            assert model_checkpoint_file.exists()
+
+            # assume stopping training to release devices
+            grpc_stub.CloseTrainerSession(training_session_id)
+
+            # attempt to init a new model with the new checkpoint and start training
+            training_session_id = grpc_stub.Init(
+                training_pb2.TrainingConfig(yaml_content=prepare_unet2d_test_environment(resume=model_checkpoint_file))
+            )
+            grpc_stub.Start(training_session_id)
+
+    def test_export(self, grpc_stub):
+        training_session_id = grpc_stub.Init(
+            training_pb2.TrainingConfig(yaml_content=prepare_unet2d_test_environment())
+        )
+
+        grpc_stub.Start(training_session_id)
+
+        with tempfile.TemporaryDirectory() as model_checkpoint_dir:
+            model_export_file = Path(model_checkpoint_dir) / "bioimageio.zip"
+            export_request = training_pb2.ExportRequest(
+                modelSessionId=training_session_id, filePath=str(model_export_file)
+            )
+            grpc_stub.Export(export_request)
+            assert model_export_file.exists()
+
+            # assume stopping training since model is exported
+            grpc_stub.CloseTrainerSession(training_session_id)
 
     def test_close_session(self, grpc_stub):
         """

--- a/tiktorch/proto/training_pb2.py
+++ b/tiktorch/proto/training_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 from . import utils_pb2 as utils__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0etraining.proto\x12\x08training\x1a\x0butils.proto\"%\n\x17GetBestModelIdxResponse\x12\n\n\x02id\x18\x01 \x01(\t\"\x87\x01\n\x04Logs\x12\'\n\x04mode\x18\x01 \x01(\x0e\x32\x19.training.Logs.ModelPhase\x12\x12\n\neval_score\x18\x02 \x01(\x01\x12\x0c\n\x04loss\x18\x03 \x01(\x01\x12\x11\n\titeration\x18\x04 \x01(\r\"!\n\nModelPhase\x12\t\n\x05Train\x10\x00\x12\x08\n\x04\x45val\x10\x01\"L\n\x14StreamUpdateResponse\x12\x16\n\x0e\x62\x65st_model_idx\x18\x01 \x01(\r\x12\x1c\n\x04logs\x18\x02 \x01(\x0b\x32\x0e.training.Logs\"/\n\x0fGetLogsResponse\x12\x1c\n\x04logs\x18\x01 \x03(\x0b\x32\x0e.training.Logs\"6\n\x12ValidationResponse\x12 \n\x18validation_score_average\x18\x01 \x01(\x01\"\x8b\x01\n\x11GetStatusResponse\x12\x30\n\x05state\x18\x01 \x01(\x0e\x32!.training.GetStatusResponse.State\"D\n\x05State\x12\x08\n\x04Idle\x10\x00\x12\x0b\n\x07Running\x10\x01\x12\n\n\x06Paused\x10\x02\x12\n\n\x06\x46\x61iled\x10\x03\x12\x0c\n\x08\x46inished\x10\x04\",\n\x1eGetCurrentBestModelIdxResponse\x12\n\n\x02id\x18\x01 \x01(\r\"&\n\x0eTrainingConfig\x12\x14\n\x0cyaml_content\x18\x01 \x01(\t2\x80\x04\n\x08Training\x12!\n\x0bListDevices\x12\x06.Empty\x1a\x08.Devices\"\x00\x12\x31\n\x04Init\x12\x18.training.TrainingConfig\x1a\r.ModelSession\"\x00\x12 \n\x05Start\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12!\n\x06Resume\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12 \n\x05Pause\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12\x42\n\rStreamUpdates\x12\r.ModelSession\x1a\x1e.training.StreamUpdateResponse\"\x00\x30\x01\x12\x35\n\x07GetLogs\x12\r.ModelSession\x1a\x19.training.GetLogsResponse\"\x00\x12!\n\x06\x45xport\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12.\n\x07Predict\x12\x0f.PredictRequest\x1a\x10.PredictResponse\"\x00\x12\x39\n\tGetStatus\x12\r.ModelSession\x1a\x1b.training.GetStatusResponse\"\x00\x12.\n\x13\x43loseTrainerSession\x12\r.ModelSession\x1a\x06.Empty\"\x00\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0etraining.proto\x12\x08training\x1a\x0butils.proto\"%\n\x17GetBestModelIdxResponse\x12\n\n\x02id\x18\x01 \x01(\t\"\x87\x01\n\x04Logs\x12\'\n\x04mode\x18\x01 \x01(\x0e\x32\x19.training.Logs.ModelPhase\x12\x12\n\neval_score\x18\x02 \x01(\x01\x12\x0c\n\x04loss\x18\x03 \x01(\x01\x12\x11\n\titeration\x18\x04 \x01(\r\"!\n\nModelPhase\x12\t\n\x05Train\x10\x00\x12\x08\n\x04\x45val\x10\x01\"L\n\x14StreamUpdateResponse\x12\x16\n\x0e\x62\x65st_model_idx\x18\x01 \x01(\r\x12\x1c\n\x04logs\x18\x02 \x01(\x0b\x32\x0e.training.Logs\"/\n\x0fGetLogsResponse\x12\x1c\n\x04logs\x18\x01 \x03(\x0b\x32\x0e.training.Logs\"F\n\x0bSaveRequest\x12%\n\x0emodelSessionId\x18\x01 \x01(\x0b\x32\r.ModelSession\x12\x10\n\x08\x66ilePath\x18\x02 \x01(\t\"H\n\rExportRequest\x12%\n\x0emodelSessionId\x18\x01 \x01(\x0b\x32\r.ModelSession\x12\x10\n\x08\x66ilePath\x18\x02 \x01(\t\"6\n\x12ValidationResponse\x12 \n\x18validation_score_average\x18\x01 \x01(\x01\"\x8b\x01\n\x11GetStatusResponse\x12\x30\n\x05state\x18\x01 \x01(\x0e\x32!.training.GetStatusResponse.State\"D\n\x05State\x12\x08\n\x04Idle\x10\x00\x12\x0b\n\x07Running\x10\x01\x12\n\n\x06Paused\x10\x02\x12\n\n\x06\x46\x61iled\x10\x03\x12\x0c\n\x08\x46inished\x10\x04\",\n\x1eGetCurrentBestModelIdxResponse\x12\n\n\x02id\x18\x01 \x01(\r\"&\n\x0eTrainingConfig\x12\x14\n\x0cyaml_content\x18\x01 \x01(\t2\xb3\x04\n\x08Training\x12!\n\x0bListDevices\x12\x06.Empty\x1a\x08.Devices\"\x00\x12\x31\n\x04Init\x12\x18.training.TrainingConfig\x1a\r.ModelSession\"\x00\x12 \n\x05Start\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12!\n\x06Resume\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12 \n\x05Pause\x12\r.ModelSession\x1a\x06.Empty\"\x00\x12\x42\n\rStreamUpdates\x12\r.ModelSession\x1a\x1e.training.StreamUpdateResponse\"\x00\x30\x01\x12\x35\n\x07GetLogs\x12\r.ModelSession\x1a\x19.training.GetLogsResponse\"\x00\x12\'\n\x04Save\x12\x15.training.SaveRequest\x1a\x06.Empty\"\x00\x12+\n\x06\x45xport\x12\x17.training.ExportRequest\x1a\x06.Empty\"\x00\x12.\n\x07Predict\x12\x0f.PredictRequest\x1a\x10.PredictResponse\"\x00\x12\x39\n\tGetStatus\x12\r.ModelSession\x1a\x1b.training.GetStatusResponse\"\x00\x12.\n\x13\x43loseTrainerSession\x12\r.ModelSession\x1a\x06.Empty\"\x00\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'training_pb2', globals())
@@ -31,16 +31,20 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _STREAMUPDATERESPONSE._serialized_end=294
   _GETLOGSRESPONSE._serialized_start=296
   _GETLOGSRESPONSE._serialized_end=343
-  _VALIDATIONRESPONSE._serialized_start=345
-  _VALIDATIONRESPONSE._serialized_end=399
-  _GETSTATUSRESPONSE._serialized_start=402
-  _GETSTATUSRESPONSE._serialized_end=541
-  _GETSTATUSRESPONSE_STATE._serialized_start=473
-  _GETSTATUSRESPONSE_STATE._serialized_end=541
-  _GETCURRENTBESTMODELIDXRESPONSE._serialized_start=543
-  _GETCURRENTBESTMODELIDXRESPONSE._serialized_end=587
-  _TRAININGCONFIG._serialized_start=589
-  _TRAININGCONFIG._serialized_end=627
-  _TRAINING._serialized_start=630
-  _TRAINING._serialized_end=1142
+  _SAVEREQUEST._serialized_start=345
+  _SAVEREQUEST._serialized_end=415
+  _EXPORTREQUEST._serialized_start=417
+  _EXPORTREQUEST._serialized_end=489
+  _VALIDATIONRESPONSE._serialized_start=491
+  _VALIDATIONRESPONSE._serialized_end=545
+  _GETSTATUSRESPONSE._serialized_start=548
+  _GETSTATUSRESPONSE._serialized_end=687
+  _GETSTATUSRESPONSE_STATE._serialized_start=619
+  _GETSTATUSRESPONSE_STATE._serialized_end=687
+  _GETCURRENTBESTMODELIDXRESPONSE._serialized_start=689
+  _GETCURRENTBESTMODELIDXRESPONSE._serialized_end=733
+  _TRAININGCONFIG._serialized_start=735
+  _TRAININGCONFIG._serialized_end=773
+  _TRAINING._serialized_start=776
+  _TRAINING._serialized_end=1339
 # @@protoc_insertion_point(module_scope)

--- a/tiktorch/proto/training_pb2_grpc.py
+++ b/tiktorch/proto/training_pb2_grpc.py
@@ -50,9 +50,14 @@ class TrainingStub(object):
                 request_serializer=utils__pb2.ModelSession.SerializeToString,
                 response_deserializer=training__pb2.GetLogsResponse.FromString,
                 )
+        self.Save = channel.unary_unary(
+                '/training.Training/Save',
+                request_serializer=training__pb2.SaveRequest.SerializeToString,
+                response_deserializer=utils__pb2.Empty.FromString,
+                )
         self.Export = channel.unary_unary(
                 '/training.Training/Export',
-                request_serializer=utils__pb2.ModelSession.SerializeToString,
+                request_serializer=training__pb2.ExportRequest.SerializeToString,
                 response_deserializer=utils__pb2.Empty.FromString,
                 )
         self.Predict = channel.unary_unary(
@@ -112,6 +117,12 @@ class TrainingServicer(object):
         raise NotImplementedError('Method not implemented!')
 
     def GetLogs(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def Save(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -179,9 +190,14 @@ def add_TrainingServicer_to_server(servicer, server):
                     request_deserializer=utils__pb2.ModelSession.FromString,
                     response_serializer=training__pb2.GetLogsResponse.SerializeToString,
             ),
+            'Save': grpc.unary_unary_rpc_method_handler(
+                    servicer.Save,
+                    request_deserializer=training__pb2.SaveRequest.FromString,
+                    response_serializer=utils__pb2.Empty.SerializeToString,
+            ),
             'Export': grpc.unary_unary_rpc_method_handler(
                     servicer.Export,
-                    request_deserializer=utils__pb2.ModelSession.FromString,
+                    request_deserializer=training__pb2.ExportRequest.FromString,
                     response_serializer=utils__pb2.Empty.SerializeToString,
             ),
             'Predict': grpc.unary_unary_rpc_method_handler(
@@ -329,6 +345,23 @@ class Training(object):
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
 
     @staticmethod
+    def Save(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/training.Training/Save',
+            training__pb2.SaveRequest.SerializeToString,
+            utils__pb2.Empty.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
     def Export(request,
             target,
             options=(),
@@ -340,7 +373,7 @@ class Training(object):
             timeout=None,
             metadata=None):
         return grpc.experimental.unary_unary(request, target, '/training.Training/Export',
-            utils__pb2.ModelSession.SerializeToString,
+            training__pb2.ExportRequest.SerializeToString,
             utils__pb2.Empty.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/tiktorch/server/session/backend/base.py
+++ b/tiktorch/server/session/backend/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC
 from concurrent.futures import Future
+from pathlib import Path
 
 from bioimageio.core import PredictionPipeline, Sample
 
@@ -81,11 +82,15 @@ class TrainerSessionBackend(SessionBackend):
         self._queue_tasks.send_command(start_cmd.awaitable)
         start_cmd.awaitable.wait()
 
-    def save(self) -> None:
-        raise NotImplementedError
+    def save(self, file_path: Path) -> None:
+        save_cmd = commands.SaveTrainingCmd(file_path)
+        self._queue_tasks.send_command(save_cmd.awaitable)
+        save_cmd.awaitable.wait()
 
-    def export(self) -> None:
-        raise NotImplementedError
+    def export(self, file_path: Path) -> None:
+        export_cmd = commands.ExportTrainingCmd(file_path)
+        self._queue_tasks.send_command(export_cmd.awaitable)
+        export_cmd.awaitable.wait()
 
     def get_state(self) -> TrainerState:
         return self._supervisor.get_state()

--- a/tiktorch/server/session/backend/commands.py
+++ b/tiktorch/server/session/backend/commands.py
@@ -6,6 +6,7 @@ import queue
 import threading
 import typing
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Generic, Type, TypeVar
 
 from tiktorch.trainer import TrainerAction, TrainerState
@@ -129,6 +130,24 @@ class ShutdownCmd(ICommand):
 
     def execute(self, ctx: Context) -> None:
         pass
+
+
+class ExportTrainingCmd(ICommand):
+    def __init__(self, file_path: Path):
+        super().__init__()
+        self._file_path = file_path
+
+    def execute(self, ctx: Context[TrainerSupervisor]) -> None:
+        ctx.session.export(self._file_path)
+
+
+class SaveTrainingCmd(ICommand):
+    def __init__(self, file_path: Path):
+        super().__init__()
+        self._file_path = file_path
+
+    def execute(self, ctx: Context[TrainerSupervisor]) -> None:
+        ctx.session.save(self._file_path)
 
 
 class ShutdownWithTeardownCmd(ShutdownCmd):

--- a/tiktorch/server/session/backend/supervisor.py
+++ b/tiktorch/server/session/backend/supervisor.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from pathlib import Path
 from typing import Generic, Set, TypeVar, Union
 
 from bioimageio.core import PredictionPipeline, Sample
@@ -134,11 +135,14 @@ class TrainerSupervisor:
             self.resume()
         return res
 
-    def save(self):
-        raise NotImplementedError
+    def save(self, file_path: Path):
+        self.pause()
+        self._trainer.save_state_dict(file_path)
+        self.resume()
 
-    def export(self):
-        raise NotImplementedError
+    def export(self, file_path: Path):
+        self.pause()
+        self._trainer.export(file_path)
 
     def _should_stop(self):
         return self._pause_triggered

--- a/tiktorch/server/session/backend/supervisor.py
+++ b/tiktorch/server/session/backend/supervisor.py
@@ -136,12 +136,17 @@ class TrainerSupervisor:
         return res
 
     def save(self, file_path: Path):
-        self.pause()
+        init_state = self.get_state()  # retain the state after save
+        if init_state == TrainerState.RUNNING:
+            self.pause()
         self._trainer.save_state_dict(file_path)
-        self.resume()
+        if init_state == TrainerState.RUNNING:
+            self.resume()
 
     def export(self, file_path: Path):
-        self.pause()
+        init_state = self.get_state()
+        if init_state == TrainerState.RUNNING:
+            self.pause()
         self._trainer.export(file_path)
 
     def _should_stop(self):

--- a/tiktorch/server/session/process.py
+++ b/tiktorch/server/session/process.py
@@ -1,10 +1,10 @@
 import logging
 import multiprocessing as _mp
-import pathlib
 import tempfile
 import uuid
 from concurrent.futures import Future
 from multiprocessing.connection import Connection
+from pathlib import Path
 from typing import List, Optional, Tuple, Type, TypeVar, Union
 
 import torch
@@ -139,11 +139,11 @@ class TrainerSessionProcess(IRPCTrainer):
     def pause_training(self):
         self.worker.pause_training()
 
-    def save(self):
-        self.worker.save()
+    def save(self, file_path: Path):
+        self.worker.save(file_path)
 
-    def export(self):
-        self.worker.export()
+    def export(self, file_path: Path):
+        self.worker.export(file_path)
 
     def get_state(self):
         return self.worker.get_state()
@@ -210,7 +210,7 @@ def _get_prediction_pipeline_from_model_bytes(model_bytes: bytes, devices: List[
 def _get_model_descr_from_model_bytes(model_bytes: bytes) -> v0_5.ModelDescr:
     with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as _tmp_file:
         _tmp_file.write(model_bytes)
-        temp_file_path = pathlib.Path(_tmp_file.name)
+        temp_file_path = Path(_tmp_file.name)
     model_descr = load_description(temp_file_path, format_version="latest")
     if isinstance(model_descr, InvalidDescr):
         raise ValueError(f"Failed to load valid model descriptor {model_descr.validation_summary}")

--- a/tiktorch/server/session/rpc_interface.py
+++ b/tiktorch/server/session/rpc_interface.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import List
 
 import torch
@@ -78,11 +79,11 @@ class IRPCTrainer(RPCInterface):
         raise NotImplementedError
 
     @exposed
-    def save(self):
+    def save(self, file_path: Path):
         raise NotImplementedError
 
     @exposed
-    def export(self):
+    def export(self, file_path: Path):
         raise NotImplementedError
 
     @exposed

--- a/tiktorch/trainer.py
+++ b/tiktorch/trainer.py
@@ -310,6 +310,7 @@ class Trainer(UNetTrainer):
                     architecture=ArchitectureFromLibraryDescr(
                         import_from=f"{self.get_model_import_file_path()}",
                         callable=Identifier(f"{self.model.__class__.__name__}"),
+                        kwargs={"in_channels": self._in_channels, "out_channels": self._out_channels},
                     ),
                     pytorch_version=Version("1.1.1"),
                 )

--- a/tiktorch/trainer.py
+++ b/tiktorch/trainer.py
@@ -5,17 +5,14 @@ import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-
-import bioimageio
-
 from pathlib import Path
 from typing import Any, Callable, Generic, List, TypeVar
 
+import bioimageio
 import numpy as np
 import torch
 import xarray as xr
 import yaml
-
 from bioimageio.core import Sample
 from bioimageio.spec import save_bioimageio_package
 from bioimageio.spec.model.v0_5 import (
@@ -355,7 +352,7 @@ class Trainer(UNetTrainer):
             members={"output": self._get_bioimageio_tensor_from_pytorch_tensor(predictions)}, stat={}, id=None
         )
         return output_sample
-    
+
     def _forward(self, input_tensors: List[torch.Tensor]) -> torch.Tensor:
         """
         Note:
@@ -365,7 +362,7 @@ class Trainer(UNetTrainer):
 
             Thus, we drop the z dimension if we have 2d model.
             But the input h5 data needs to respect CxDxHxW or DxHxW.
-        """        
+        """
         assert len(input_tensors) == 1, "We support models with 1 input"
         input_tensor = input_tensors[0]
         self.model.eval()
@@ -398,7 +395,7 @@ class Trainer(UNetTrainer):
         # currently we scale the features from 0 - 1 (consistent scale for rendering across channels)
         postprocessor = Compose([Normalize(norm01=True), ToTensor(expand_dims=True)])
         predictions = self._apply_transformation(compose=postprocessor, tensor=predictions)
-        return predictions        
+        return predictions
 
     def _apply_transformation(self, compose: Compose, tensor: torch.Tensor) -> torch.Tensor:
         """

--- a/tiktorch/trainer.py
+++ b/tiktorch/trainer.py
@@ -190,7 +190,8 @@ class Trainer(UNetTrainer):
         """
         On demand save of the training progress including the optimizer state.
 
-        Note: pytorch-3dunet automatically saves the checkpoints in intervals defined by the `validation_after_iters`.
+        Note: pytorch-3dunet automatically saves two checkpoints latest.pytorch and best.pytorch.
+        The best.pytorch is updated in intervals defined by the `validation_after_iters`.
         """
         if not file_path.suffix:
             file_path = file_path.with_suffix(".pth")


### PR DESCRIPTION
It builds upon #227 .

Adding the options to save and export a model for the training service.

- Save: pytorch state dict, including the optimizer
- Export: save it as a bioimageio package (.zip)

When we save, the training is paused, and then we resume. For the export, we just pause.

TODO:
- [x] The preprocessing and the postprocessing of the pytorch-3dunet should match the ones provided by bioimageio (opened an issue https://github.com/ilastik/tiktorch/issues/231)
- [x] Investigate kwargs of the model, so bioimageio can instantiate it